### PR TITLE
Strip Series Name, Season and Episode Number that is embedded in titles

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -437,6 +437,38 @@ public class StrmSyncServiceTests
         result.Should().Be("Show - S01E01 - Unknown.strm");
     }
 
+    [Fact]
+    public void BuildEpisodeFileName_ProviderEmbeddedPrefix_StripsDoubling()
+    {
+        // Some providers embed the full series name and SxxExx in the episode title, which can cause redundant naming like "Series Name - S01E01 - Series Name S01E01"
+        var episode = TestDataBuilder.CreateEpisode(episodeNum: 1, title: "Breaking Bad - S01E01 - Pilot");
+
+        var result = StrmSyncService.BuildEpisodeFileName("Breaking Bad", 1, episode);
+
+        result.Should().Be("Breaking Bad - S01E01 - Pilot.strm");
+    }
+
+    [Fact]
+    public void BuildEpisodeFileName_ProviderEmbeddedPrefixCaseInsensitive_StripsDoubling()
+    {
+        // The check for embedded prefix should be case-insensitive
+        var episode = TestDataBuilder.CreateEpisode(episodeNum: 1, title: "breaking bad - s01e01 - Pilot");
+
+        var result = StrmSyncService.BuildEpisodeFileName("Breaking Bad", 1, episode);
+
+        result.Should().Be("Breaking Bad - S01E01 - Pilot.strm");
+    }
+
+    [Fact]
+    public void BuildEpisodeFileName_ProviderEmbeddedPrefixWithDifferentSeriesName_DoesNotStrip()
+    {
+        // If the embedded prefix doesn't match the series name, it should not be stripped (avoid stripping valid titles that just happen to start with the same text)
+        var episode = TestDataBuilder.CreateEpisode(episodeNum: 1, title: "Some Other Show - S01E01 - Pilot");
+
+        var result = StrmSyncService.BuildEpisodeFileName("Breaking Bad", 1, episode);
+
+        result.Should().Be("Breaking Bad - S01E01 - Some Other Show - S01E01 - Pilot.strm");
+    }
     #endregion
 
     #region CleanupEmptyDirectories Tests

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -2661,6 +2661,14 @@ public partial class StrmSyncService
         string seasonStr = seasonNumber.ToString("D2", System.Globalization.CultureInfo.InvariantCulture);
         string episodeStr = episode.EpisodeNum.ToString("D2", System.Globalization.CultureInfo.InvariantCulture);
 
+        // Handle cases where episode title has embedded the full series name season and episode (e.g., "SeriesName - S01E01 - ")
+        // Strip it to avoid redundant naming like "SeriesName - S01E01 - SeriesName - S01E01 -"
+        string embeddedPrefix = $"{seriesName} - S{seasonStr}E{episodeStr} - ";
+        if (episodeTitle.StartsWith(embeddedPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            episodeTitle = episodeTitle[embeddedPrefix.Length..].TrimStart();
+        }
+
         if (string.IsNullOrWhiteSpace(episodeTitle) || episodeTitle.Equals($"Episode {episode.EpisodeNum}", StringComparison.OrdinalIgnoreCase))
         {
             return $"{seriesName} - S{seasonStr}E{episodeStr}.strm";


### PR DESCRIPTION
Adding a field stripper for `episodeTitle` in `BuildEpisodeFileName` to handle cases where episode title has `Series Name`, `Season` and `Episode` (e.g., "SeriesName - S01E01 - ")

Fixes [15](https://github.com/firestaerter3/Jellyfin-Xtream-Library/issues/15)