### PR TITLE
Add regex removal patterns for STRM file names (closes #32)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -486,6 +486,135 @@ public class StrmSyncServiceTests
 
         result.Should().Be("Breaking Bad - S01E01 - Some Other Show - S01E01 - Pilot.strm");
     }
+
+    [Fact]
+    public void BuildEpisodeFileName_RegexPatternStripsTagFromFile()
+    {
+        var episode = TestDataBuilder.CreateEpisode(episodeNum: 3, title: "Pilot [Multi-Sub]");
+
+        var result = StrmSyncService.BuildEpisodeFileName(
+            seriesName: "Show",
+            seasonNumber: 1,
+            episode: episode,
+            customRemoveTerms: null,
+            regexRemovalPatterns: @"\s*\[Multi-Sub\]");
+
+        result.Should().Be("Show - S01E03 - Pilot.strm");
+    }
+
+    [Fact]
+    public void BuildEpisodeFileName_NullRegexPatterns_LeavesNameAsIs()
+    {
+        var episode = TestDataBuilder.CreateEpisode(episodeNum: 1, title: "Pilot");
+
+        var result = StrmSyncService.BuildEpisodeFileName("Show", 1, episode, customRemoveTerms: null, regexRemovalPatterns: null);
+
+        result.Should().Be("Show - S01E01 - Pilot.strm");
+    }
+    #endregion
+
+    #region ApplyFileNameRegexPatterns Tests
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_NullPatterns_ReturnsInput()
+    {
+        var result = StrmSyncService.ApplyFileNameRegexPatterns("Movie [tmdbid-1].strm", null);
+
+        result.Should().Be("Movie [tmdbid-1].strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_EmptyPatterns_ReturnsInput()
+    {
+        var result = StrmSyncService.ApplyFileNameRegexPatterns("Movie.strm", "   \n  \n");
+
+        result.Should().Be("Movie.strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_StripsTmdbIdTag()
+    {
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "The Matrix (1999) [tmdbid-603].strm",
+            @"\s*\[tmdbid-\d+\]");
+
+        result.Should().Be("The Matrix (1999).strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_StripsTvdbIdTag()
+    {
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "Breaking Bad (2008) [tvdbid-81189] - S01E01 - Pilot.strm",
+            @"\s*\[tvdbid-\d+\]");
+
+        result.Should().Be("Breaking Bad (2008) - S01E01 - Pilot.strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_MultiplePatterns_AllApplied()
+    {
+        var patterns = "\\s*\\[tmdbid-\\d+\\]\n\\s*\\[Multi-Sub\\]\n\\s+FHD";
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "Movie (2024) [tmdbid-7] [Multi-Sub] FHD.strm",
+            patterns);
+
+        result.Should().Be("Movie (2024).strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_InvalidRegex_SkippedSilently()
+    {
+        // Bad patterns should not throw and should not abort the whole list.
+        var patterns = "(unclosed\n\\s*\\[tmdbid-\\d+\\]";
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "Movie [tmdbid-1].strm",
+            patterns);
+
+        result.Should().Be("Movie.strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_ExtensionPreserved()
+    {
+        // Extension is split off so even greedy patterns can't strip it.
+        var result = StrmSyncService.ApplyFileNameRegexPatterns("Movie.strm", ".+");
+
+        // Base became empty — fall back to original to avoid producing just ".strm".
+        result.Should().Be("Movie.strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_CaseSensitiveByDefault()
+    {
+        // .NET regex is case-sensitive by default; users can opt into (?i) per pattern.
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "Movie [TMDBID-1].strm",
+            @"\s*\[tmdbid-\d+\]");
+
+        result.Should().Be("Movie [TMDBID-1].strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_CaseInsensitiveOptIn()
+    {
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "Movie [TMDBID-1].strm",
+            @"(?i)\s*\[tmdbid-\d+\]");
+
+        result.Should().Be("Movie.strm");
+    }
+
+    [Fact]
+    public void ApplyFileNameRegexPatterns_CollapsesDoubleSpaces()
+    {
+        var result = StrmSyncService.ApplyFileNameRegexPatterns(
+            "Movie  Title.strm",
+            @"NOMATCH");
+
+        // Even when no pattern matched, the tidy step still runs — single spaces only.
+        result.Should().Be("Movie Title.strm");
+    }
     #endregion
 
     #region CleanupEmptyDirectories Tests
@@ -808,6 +937,57 @@ public class StrmSyncServiceTests
         var result = StrmSyncService.BuildMovieStrmFileName("Folder", "HEVC 4K");
 
         result.Should().Be("Folder - HEVC 4K.strm");
+    }
+
+    [Fact]
+    public void BuildMovieStrmFileName_RegexPatternStripsTmdbIdFromFile()
+    {
+        // The folder name keeps [tmdbid-N] (used by Jellyfin metadata identification),
+        // but the file name is cleaned for downstream tools like OpenSubtitles.
+        var result = StrmSyncService.BuildMovieStrmFileName(
+            "The Matrix (1999) [tmdbid-603]",
+            null,
+            @"\s*\[tmdbid-\d+\]");
+
+        result.Should().Be("The Matrix (1999).strm");
+    }
+
+    [Fact]
+    public void BuildMovieStrmFileName_RegexNullPatterns_LeavesFileNameAsIs()
+    {
+        var result = StrmSyncService.BuildMovieStrmFileName("Folder [tmdbid-1]", null, null);
+
+        result.Should().Be("Folder [tmdbid-1].strm");
+    }
+
+    [Fact]
+    public void BuildMovieStrmFileName_InvalidRegex_DoesNotThrow()
+    {
+        // Bad pattern is silently skipped — sync should not break on a typo.
+        var result = StrmSyncService.BuildMovieStrmFileName("Folder [tmdbid-7]", null, "(unclosed");
+
+        result.Should().Be("Folder [tmdbid-7].strm");
+    }
+
+    [Fact]
+    public void BuildMovieStrmFileName_MultiplePatterns_AppliedInOrder()
+    {
+        var patterns = "\\s*\\[tmdbid-\\d+\\]\n\\s*\\[Multi-Sub\\]";
+        var result = StrmSyncService.BuildMovieStrmFileName(
+            "Movie [tmdbid-42] [Multi-Sub]",
+            null,
+            patterns);
+
+        result.Should().Be("Movie.strm");
+    }
+
+    [Fact]
+    public void BuildMovieStrmFileName_RegexExtensionPreserved()
+    {
+        // A greedy pattern shouldn't be able to eat ".strm" — extension is split off first.
+        var result = StrmSyncService.BuildMovieStrmFileName("Movie", null, ".+");
+
+        result.Should().Be("Movie.strm");
     }
 
     #endregion

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -400,6 +400,17 @@
                                     Applied before built-in title cleaning (language tags, codec info, quality tags, etc.).
                                 </div>
                             </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtRegexRemovalPatterns">Regex Removal Patterns (file names only, one per line)</label>
+                                <textarea is="emby-textarea" id="txtRegexRemovalPatterns" rows="4"
+                                    placeholder="\s*\[tmdbid-\d+\]&#10;\s*\[tvdbid-\d+\]" style="width: 100%; font-family: monospace;"></textarea>
+                                <div class="fieldDescription">
+                                    .NET regex patterns to remove from STRM <strong>file names only</strong>. Folder names are left
+                                    untouched, so tags like <code>[tmdbid-N]</code> remain available for Jellyfin's metadata
+                                    identification. Useful for cleaning file names for tools like OpenSubtitles. One pattern per
+                                    line. Invalid patterns are skipped with a warning and do not abort the sync.
+                                </div>
+                            </div>
                         </div>
 
                         <div class="verticalSection">

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -80,6 +80,8 @@ const XtreamLibraryConfig = {
             // Custom title removal terms
             var txtCustomTerms = document.getElementById('txtCustomTitleRemoveTerms');
             if (txtCustomTerms) txtCustomTerms.value = config.CustomTitleRemoveTerms || '';
+            var txtRegexPatterns = document.getElementById('txtRegexRemovalPatterns');
+            if (txtRegexPatterns) txtRegexPatterns.value = config.RegexRemovalPatterns || '';
             document.getElementById('txtSyncParallelism').value = config.SyncParallelism || 10;
             document.getElementById('txtCategoryBatchSize').value = config.CategoryBatchSize || 25;
 
@@ -210,6 +212,8 @@ const XtreamLibraryConfig = {
             // Custom title removal terms
             var txtCustomTermsSave = document.getElementById('txtCustomTitleRemoveTerms');
             if (txtCustomTermsSave) config.CustomTitleRemoveTerms = txtCustomTermsSave.value;
+            var txtRegexPatternsSave = document.getElementById('txtRegexRemovalPatterns');
+            if (txtRegexPatternsSave) config.RegexRemovalPatterns = txtRegexPatternsSave.value;
 
             // Rate limiting
             config.RequestDelayMs = parseInt(document.getElementById('txtRequestDelayMs').value) || 50;

--- a/Jellyfin.Xtream.Library/PluginConfiguration.cs
+++ b/Jellyfin.Xtream.Library/PluginConfiguration.cs
@@ -144,6 +144,15 @@ public class PluginConfiguration : BasePluginConfiguration
     public string CustomTitleRemoveTerms { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets regex patterns to remove from STRM file names.
+    /// One .NET regex per line. Applied to file names ONLY (not folder names),
+    /// so folders keep tags Jellyfin uses for metadata identification (e.g. [tmdbid-N]).
+    /// Invalid patterns are skipped with a warning and do not abort the sync.
+    /// Useful for cleaning file names for downstream tools like OpenSubtitles.
+    /// </summary>
+    public string RegexRemovalPatterns { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to download artwork from the provider
     /// for content that could not be matched to TMDb/TVDb.
     /// This ensures unmatched content still has posters and thumbnails.

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -357,12 +357,13 @@ public partial class StrmSyncService
     {
         // Use stored item info to build the STRM file directly
         var customTerms = Plugin.Instance.Configuration.CustomTitleRemoveTerms;
+        var regexPatterns = Plugin.Instance.Configuration.RegexRemovalPatterns;
         string movieName = SanitizeFileName(item.Name, customTerms);
         int? year = ExtractYear(item.Name);
         string folderName = year.HasValue ? $"{movieName} ({year})" : movieName;
         string? versionLabel = ExtractVersionLabel(item.Name);
         string movieFolder = Path.Combine(moviesPath, folderName);
-        string strmFileName = BuildMovieStrmFileName(folderName, versionLabel);
+        string strmFileName = BuildMovieStrmFileName(folderName, versionLabel, regexPatterns);
         string strmPath = Path.Combine(movieFolder, strmFileName);
 
         // Build stream URL using stored item ID (assume mp4 as default extension)
@@ -407,6 +408,7 @@ public partial class StrmSyncService
         }
 
         var customTerms = Plugin.Instance.Configuration.CustomTitleRemoveTerms;
+        var regexPatterns = Plugin.Instance.Configuration.RegexRemovalPatterns;
         string seriesName = SanitizeFileName(item.Name, customTerms);
         int? year = ExtractYear(item.Name);
         string seriesFolderName = year.HasValue ? $"{seriesName} ({year})" : seriesName;
@@ -424,7 +426,7 @@ public partial class StrmSyncService
 
             foreach (var episode in episodes)
             {
-                string episodeFileName = BuildEpisodeFileName(seriesName, seasonNumber, episode, customTerms);
+                string episodeFileName = BuildEpisodeFileName(seriesName, seasonNumber, episode, customTerms, regexPatterns);
                 string strmPath = Path.Combine(seasonFolder, episodeFileName);
 
                 string extension = string.IsNullOrEmpty(episode.ContainerExtension) ? "mkv" : episode.ContainerExtension;
@@ -1567,7 +1569,7 @@ public partial class StrmSyncService
                         for (int i = 0; i < providers.Count; i++)
                         {
                             string providerStreamUrl = $"{connectionInfo.BaseUrl}/proxy/vod/movie/{uuid}?stream_id={providers[i].StreamId}";
-                            string strmFileName = BuildMovieStrmFileName(folderName, i == 0 ? null : $"Version {i + 1}");
+                            string strmFileName = BuildMovieStrmFileName(folderName, i == 0 ? null : $"Version {i + 1}", config.RegexRemovalPatterns);
                             strmEntries.Add((providerStreamUrl, strmFileName));
                         }
                     }
@@ -1575,7 +1577,7 @@ public partial class StrmSyncService
                     {
                         string extension = string.IsNullOrEmpty(stream.ContainerExtension) ? "mp4" : stream.ContainerExtension;
                         string streamUrl = $"{connectionInfo.BaseUrl}/movie/{connectionInfo.UserName}/{connectionInfo.Password}/{stream.StreamId}.{extension}";
-                        string strmFileName = BuildMovieStrmFileName(folderName, versionLabel);
+                        string strmFileName = BuildMovieStrmFileName(folderName, versionLabel, config.RegexRemovalPatterns);
                         strmEntries.Add((streamUrl, strmFileName));
                     }
 
@@ -2445,7 +2447,7 @@ public partial class StrmSyncService
 
                             foreach (var episode in episodes)
                             {
-                                string episodeFileName = BuildEpisodeFileName(seriesName, seasonNumber, episode, config.CustomTitleRemoveTerms);
+                                string episodeFileName = BuildEpisodeFileName(seriesName, seasonNumber, episode, config.CustomTitleRemoveTerms, config.RegexRemovalPatterns);
                                 string strmPath = Path.Combine(seasonFolder, episodeFileName);
 
                                 syncedFiles.TryAdd(strmPath, 0);
@@ -2652,7 +2654,7 @@ public partial class StrmSyncService
         CurrentProgress.SeriesPhase = string.Empty;
     }
 
-    internal static string BuildEpisodeFileName(string seriesName, int seasonNumber, Episode episode, string? customRemoveTerms = null)
+    internal static string BuildEpisodeFileName(string seriesName, int seasonNumber, Episode episode, string? customRemoveTerms = null, string? regexRemovalPatterns = null)
     {
         string episodeTitle = SanitizeFileName(episode.Title, customRemoveTerms);
         string seasonStr = seasonNumber.ToString("D2", System.Globalization.CultureInfo.InvariantCulture);
@@ -2666,12 +2668,17 @@ public partial class StrmSyncService
             episodeTitle = episodeTitle[embeddedPrefix.Length..].TrimStart();
         }
 
+        string fileName;
         if (string.IsNullOrWhiteSpace(episodeTitle) || episodeTitle.Equals($"Episode {episode.EpisodeNum}", StringComparison.OrdinalIgnoreCase))
         {
-            return $"{seriesName} - S{seasonStr}E{episodeStr}.strm";
+            fileName = $"{seriesName} - S{seasonStr}E{episodeStr}.strm";
+        }
+        else
+        {
+            fileName = $"{seriesName} - S{seasonStr}E{episodeStr} - {episodeTitle}.strm";
         }
 
-        return $"{seriesName} - S{seasonStr}E{episodeStr} - {episodeTitle}.strm";
+        return ApplyFileNameRegexPatterns(fileName, regexRemovalPatterns);
     }
 
     internal static string SanitizeFileName(string? name, string? customRemoveTerms = null)
@@ -2773,11 +2780,69 @@ public partial class StrmSyncService
         return labels.Count > 0 ? string.Join(" ", labels) : null;
     }
 
-    internal static string BuildMovieStrmFileName(string folderName, string? versionLabel)
+    internal static string BuildMovieStrmFileName(string folderName, string? versionLabel, string? regexRemovalPatterns = null)
     {
-        return versionLabel != null
+        string fileName = versionLabel != null
             ? $"{folderName} - {versionLabel}.strm"
             : $"{folderName}.strm";
+
+        return ApplyFileNameRegexPatterns(fileName, regexRemovalPatterns);
+    }
+
+    /// <summary>
+    /// Applies user-supplied regex removal patterns to a file name. Patterns are one per line.
+    /// The .strm extension is preserved. Invalid patterns are skipped silently (no exception).
+    /// Use this for file names only — folder names must keep tags like [tmdbid-N] for Jellyfin metadata identification.
+    /// </summary>
+    /// <param name="fileName">The file name (with extension) to clean.</param>
+    /// <param name="regexRemovalPatterns">Newline-separated .NET regex patterns. Empty/null is a no-op.</param>
+    /// <returns>The file name with all valid patterns replaced with empty string and whitespace tidied.</returns>
+    internal static string ApplyFileNameRegexPatterns(string fileName, string? regexRemovalPatterns)
+    {
+        if (string.IsNullOrEmpty(fileName) || string.IsNullOrWhiteSpace(regexRemovalPatterns))
+        {
+            return fileName;
+        }
+
+        // Split off the extension so regex patterns can't accidentally strip ".strm".
+        string extension = Path.GetExtension(fileName);
+        string baseName = string.IsNullOrEmpty(extension)
+            ? fileName
+            : fileName[..^extension.Length];
+
+        foreach (var rawPattern in regexRemovalPatterns.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string pattern = rawPattern.Trim();
+            if (pattern.Length == 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                // Bounded timeout protects against catastrophic backtracking.
+                baseName = Regex.Replace(baseName, pattern, string.Empty, RegexOptions.None, TimeSpan.FromSeconds(1));
+            }
+            catch (ArgumentException)
+            {
+                // Invalid regex syntax — skip this pattern, keep going.
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Pattern was valid but ran too long — skip this pattern, keep going.
+            }
+        }
+
+        // Tidy up: collapse runs of spaces, trim separators left behind by the removal.
+        baseName = MultipleSpacesPattern().Replace(baseName, " ").Trim(' ', '_', '-', '.');
+
+        if (string.IsNullOrEmpty(baseName))
+        {
+            // Don't return just the extension — fall back to the original to keep things sane.
+            return fileName;
+        }
+
+        return baseName + extension;
     }
 
     internal static int? ExtractYear(string? name)


### PR DESCRIPTION
Adds a "Regex Removal Patterns" config field next to the existing "Custom Title Removal Terms" textarea. Patterns apply to STRM file names only. Folder names are intentionally left alone so Jellyfin's metadata providers can still use [tmdbid-N] / [tvdbid-N] tags to lock identification.

Invalid patterns are skipped silently so a bad rule doesn't abort the sync. Each replacement has a 1s timeout to guard against runaway regex.

The two example patterns from the issue both work as written:
- `^(EN|DK)\s-\s`
- `\s\[tmdbid-\d+\]`

17 new unit tests cover the helper and the two filename builders. All 357 tests pass.

Closes #32.