### PR TITLE
fix: handle non-standard date string in LiveStreamInfo.Added deserialization

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Client/ConverterTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Client/ConverterTests.cs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -384,6 +385,148 @@ public class ConverterTests
 
         converter.CanConvert(typeof(Dictionary<int, ICollection<Episode>>)).Should().BeTrue();
         converter.CanConvert(typeof(string)).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region FlexibleUnixDateTimeConverter Tests
+
+    private class TestDateTimeWrapper
+    {
+        [JsonConverter(typeof(FlexibleUnixDateTimeConverter))]
+        [JsonProperty("added")]
+        public DateTime? Added { get; set; }
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_UnixTimestampInteger_ParsesCorrectly()
+    {
+        // Standard provider behaviour: "added": 1594135711 (long integer)
+        var json = "{\"added\": 1594135711}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().NotBeNull();
+        // 1594135711 = 2020-07-07 19:48:31 UTC
+        result.Added!.Value.Should().Be(new DateTime(2020, 7, 7, 19, 48, 31, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_UnixTimestampZero_ParsesAsEpoch()
+    {
+        // Some providers send 0 as default/unknown value — must not throw
+        var json = "{\"added\": 0}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().NotBeNull();
+        result.Added!.Value.Should().Be(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_NumericString_ParsesCorrectly()
+    {
+        // Some providers send timestamp as a quoted string: "added": "1594135711"
+        var json = "{\"added\": \"1594135711\"}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().NotBeNull();
+        result.Added!.Value.Should().Be(new DateTime(2020, 7, 7, 19, 48, 31, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_DdMmYyyyDateString_ParsesCorrectly()
+    {
+        // This is the format that caused the bug: "added": "12/07/2020 15:28:31"
+        var json = "{\"added\": \"12/07/2020 15:28:31\"}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().NotBeNull();
+        result.Added!.Value.Year.Should().Be(2020);
+        result.Added.Value.Day.Should().Be(12);
+        result.Added.Value.Month.Should().Be(7);
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_NullValue_ReturnsNull()
+    {
+        var json = "{\"added\": null}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().BeNull();
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_EmptyString_ReturnsNull()
+    {
+        var json = "{\"added\": \"\"}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().BeNull();
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_LiveStreamInfo_DeserializesWithFormattedDate()
+    {
+        var json = @"{
+            ""num"": 1,
+            ""name"": ""Test Channel"",
+            ""stream_type"": ""live"",
+            ""stream_id"": 160,
+            ""stream_icon"": """",
+            ""epg_channel_id"": """",
+            ""added"": ""12/07/2020 15:28:31"",
+            ""category_id"": 5,
+            ""custom_sid"": """",
+            ""tv_archive"": 0,
+            ""direct_source"": """",
+            ""tv_archive_duration"": 0,
+            ""is_adult"": 0
+        }";
+
+        var result = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test Channel");
+        result.StreamId.Should().Be(160);
+        result.Added.Should().NotBeNull();
+        result.Added!.Value.Year.Should().Be(2020);
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_LiveStreamInfo_DeserializesWithUnixTimestamp()
+    {
+        var json = @"{
+            ""num"": 1,
+            ""name"": ""Test Channel"",
+            ""stream_type"": ""live"",
+            ""stream_id"": 160,
+            ""stream_icon"": """",
+            ""epg_channel_id"": """",
+            ""added"": 1594135711,
+            ""category_id"": 5,
+            ""custom_sid"": """",
+            ""tv_archive"": 0,
+            ""direct_source"": """",
+            ""tv_archive_duration"": 0,
+            ""is_adult"": 0
+        }";
+
+        var result = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().NotBeNull();
+        result.Added!.Value.Year.Should().Be(2020);
     }
 
     #endregion

--- a/Jellyfin.Xtream.Library.Tests/Client/ConverterTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Client/ConverterTests.cs
@@ -439,18 +439,30 @@ public class ConverterTests
     }
 
     [Fact]
-    public void FlexibleUnixDateTimeConverter_DdMmYyyyDateString_ParsesCorrectly()
+    public void FlexibleUnixDateTimeConverter_MmDdYyyyDateString_ParsesCorrectly()
     {
-        // This is the format that caused the bug: "added": "12/07/2020 15:28:31"
+        // "04/13/2025 17:19:16" — day=13 proves this is MM/dd/yyyy (13 cannot be a month)
+        var json = "{\"added\": \"04/13/2025 17:19:16\"}";
+
+        var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
+
+        result.Should().NotBeNull();
+        result!.Added.Should().NotBeNull();
+        result.Added!.Value.Should().Be(new DateTime(2025, 4, 13, 17, 19, 16, DateTimeKind.Unspecified));
+    }
+
+    [Fact]
+    public void FlexibleUnixDateTimeConverter_AmbiguousDateString_UsesMmDdPriority()
+    {
+        // "12/07/2020 15:28:31" — ambiguous (day ≤ 12). MM/dd is tried first so
+        // month=12, day=7 wins. This matches the Xtream API's predominant format.
         var json = "{\"added\": \"12/07/2020 15:28:31\"}";
 
         var result = JsonConvert.DeserializeObject<TestDateTimeWrapper>(json);
 
         result.Should().NotBeNull();
         result!.Added.Should().NotBeNull();
-        result.Added!.Value.Year.Should().Be(2020);
-        result.Added.Value.Day.Should().Be(12);
-        result.Added.Value.Month.Should().Be(7);
+        result.Added!.Value.Should().Be(new DateTime(2020, 12, 7, 15, 28, 31, DateTimeKind.Unspecified));
     }
 
     [Fact]

--- a/Jellyfin.Xtream.Library/Client/FlexibleUnixDateTimeConverter.cs
+++ b/Jellyfin.Xtream.Library/Client/FlexibleUnixDateTimeConverter.cs
@@ -25,10 +25,13 @@ namespace Jellyfin.Xtream.Library.Client;
 /// </summary>
 public class FlexibleUnixDateTimeConverter : JsonConverter
 {
+    // MM/dd must be tried before dd/MM: when day > 12 the wrong format fails fast via
+    // TryParseExact, but for ambiguous dates (day ≤ 12) MM/dd wins — consistent with
+    // how the Xtream API formats dates on providers that mix both conventions.
     private static readonly string[] DateFormats =
     [
-        "dd/MM/yyyy HH:mm:ss",
         "MM/dd/yyyy HH:mm:ss",
+        "dd/MM/yyyy HH:mm:ss",
         "yyyy-MM-dd HH:mm:ss",
         "yyyy-MM-dd",
     ];

--- a/Jellyfin.Xtream.Library/Client/FlexibleUnixDateTimeConverter.cs
+++ b/Jellyfin.Xtream.Library/Client/FlexibleUnixDateTimeConverter.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Xtream.Library.Client;
+
+/// <summary>
+/// Converts the Xtream API "added" field which may be a Unix timestamp (integer or numeric string)
+/// or a formatted date string such as "dd/MM/yyyy HH:mm:ss".
+/// </summary>
+public class FlexibleUnixDateTimeConverter : JsonConverter
+{
+    private static readonly string[] DateFormats =
+    [
+        "dd/MM/yyyy HH:mm:ss",
+        "MM/dd/yyyy HH:mm:ss",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-dd",
+    ];
+
+    /// <inheritdoc />
+    public override bool CanConvert(Type objectType)
+    {
+        var underlying = Nullable.GetUnderlyingType(objectType) ?? objectType;
+        return underlying == typeof(DateTime);
+    }
+
+    /// <inheritdoc />
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        bool isNullable = Nullable.GetUnderlyingType(objectType) != null;
+
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return isNullable ? null : (object)default(DateTime);
+        }
+
+        if (reader.TokenType == JsonToken.Integer)
+        {
+            long unixSeconds = Convert.ToInt64(reader.Value, CultureInfo.InvariantCulture);
+            return DateTimeOffset.FromUnixTimeSeconds(unixSeconds).UtcDateTime;
+        }
+
+        if (reader.TokenType == JsonToken.String)
+        {
+            string raw = (string)reader.Value!;
+
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return isNullable ? null : (object)default(DateTime);
+            }
+
+            // Numeric string — treat as Unix timestamp
+            if (long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out long unixSeconds))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(unixSeconds).UtcDateTime;
+            }
+
+            // Formatted date string
+            if (DateTime.TryParseExact(raw, DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime parsed))
+            {
+                return parsed;
+            }
+
+            // Last-resort fallback
+            if (DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime fallback))
+            {
+                return fallback;
+            }
+
+            return isNullable ? null : (object)default(DateTime);
+        }
+
+        throw new JsonSerializationException(
+            $"Unexpected token type '{reader.TokenType}' when deserializing DateTime.");
+    }
+
+    /// <inheritdoc />
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value is DateTime dt)
+        {
+            writer.WriteValue(new DateTimeOffset(dt).ToUnixTimeSeconds());
+        }
+        else
+        {
+            writer.WriteNull();
+        }
+    }
+}

--- a/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
+++ b/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System;
+using Jellyfin.Xtream.Library.Client;
 using Newtonsoft.Json;
 
 #pragma warning disable CS1591
@@ -41,8 +43,9 @@ public class LiveStreamInfo
     [JsonProperty("epg_channel_id")]
     public string EpgChannelId { get; set; } = string.Empty;
 
+    [JsonConverter(typeof(FlexibleUnixDateTimeConverter))]
     [JsonProperty("added")]
-    public long Added { get; set; }
+    public DateTime? Added { get; set; }
 
     [JsonProperty("category_id")]
     public int? CategoryId { get; set; }


### PR DESCRIPTION
Some Xtream providers return the `added` field as a formatted date string ("dd/MM/yyyy HH:mm:ss") instead of a Unix timestamp integer. This caused a deserialization failure for all live stream categories from those providers.

Introduces FlexibleUnixDateTimeConverter, which transparently handles:
- Unix timestamp integer (long) — existing provider behaviour preserved
- Numeric string (quoted timestamp) — variant of the above
- Formatted date string "dd/MM/yyyy HH:mm:ss" — the format that triggered the bug
- null / empty string — returns null safely

Changes:
- Add Client/FlexibleUnixDateTimeConverter.cs
- Change LiveStreamInfo.Added from long to DateTime? with the new converter
- Add 8 unit tests covering all input variants