### PR TITLE
fix: missing EPG information

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/EpgParsingTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/EpgParsingTests.cs
@@ -1,0 +1,29 @@
+
+using System;
+using System.Reflection;
+using Jellyfin.Xtream.Library.Service;
+using Xunit;
+using FluentAssertions;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class EpgParsingTests
+{
+    [Theory]
+    [InlineData("20240522100000 +0200", 1716364800)]
+    [InlineData("20240522100000 +02:00", 1716364800)]
+    [InlineData("202405221000 +0000", 1716372000)]
+    [InlineData("20240522 +0000", 1716336000)]
+    [InlineData("20240522100000", 1716372000)] // Defaults to +0000
+    [InlineData("20240522100000 -0500", 1716390000)]
+    [InlineData("20240522100000 -05:00", 1716390000)]
+    public void TryParseXmltvTime_HandlesVariousFormats(string input, long expectedUnix)
+    {
+        var method = typeof(LiveTvService).GetMethod("TryParseXmltvTime", BindingFlags.Static | BindingFlags.NonPublic);
+        var args = new object[] { input, 0L };
+        var result = (bool)method.Invoke(null, args);
+
+        result.Should().BeTrue();
+        ((long)args[1]).Should().Be(expectedUnix);
+    }
+}

--- a/Jellyfin.Xtream.Library/Service/LiveTvService.cs
+++ b/Jellyfin.Xtream.Library/Service/LiveTvService.cs
@@ -423,6 +423,8 @@ public class LiveTvService : IDisposable
     {
         var written = 0;
         var nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        // Keep programs that ended up to 1 hour ago to be resilient to timezone/clock skews
+        var pastGraceUnix = nowUnix - 3600;
         var endUnix = DateTimeOffset.UtcNow.AddDays(config.EpgDaysToFetch).ToUnixTimeSeconds();
 
         var settings = new XmlReaderSettings
@@ -437,12 +439,14 @@ public class LiveTvService : IDisposable
             using var stringReader = new StringReader(upstreamXml);
             using var reader = XmlReader.Create(stringReader, settings);
 
-            while (reader.Read())
+            reader.MoveToContent();
+            while (!reader.EOF)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (reader.NodeType != XmlNodeType.Element || reader.Name != "programme")
                 {
+                    reader.Read();
                     continue;
                 }
 
@@ -456,7 +460,7 @@ public class LiveTvService : IDisposable
                 // Optional time-window filter to keep the EPG file proportional to EpgDaysToFetch.
                 var startAttr = reader.GetAttribute("start");
                 var stopAttr = reader.GetAttribute("stop");
-                if (TryParseXmltvTime(stopAttr, out var stopUnix) && stopUnix < nowUnix)
+                if (TryParseXmltvTime(stopAttr, out var stopUnix) && stopUnix < pastGraceUnix)
                 {
                     reader.Skip();
                     continue;
@@ -502,13 +506,21 @@ public class LiveTvService : IDisposable
         }
 
         // XMLTV format: "YYYYMMDDHHMMSS +ZZZZ" (offset optional)
+        // Can also be "YYYYMMDDHHMMSS +ZZ:ZZ" or "YYYYMMDDHHMM" or "YYYYMMDD"
         var space = value.IndexOf(' ', StringComparison.Ordinal);
         var datePart = space >= 0 ? value.Substring(0, space) : value;
         var offsetPart = space >= 0 ? value.Substring(space + 1) : "+0000";
 
-        if (!DateTime.TryParseExact(datePart, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+        string[] formats = { "yyyyMMddHHmmss", "yyyyMMddHHmm", "yyyyMMdd" };
+        if (!DateTime.TryParseExact(datePart, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
         {
             return false;
+        }
+
+        // Normalize offsetPart: handle +HH:MM by removing the colon
+        if (offsetPart.Contains(':', StringComparison.Ordinal))
+        {
+            offsetPart = offsetPart.Replace(":", string.Empty, StringComparison.Ordinal);
         }
 
         var offset = TimeSpan.Zero;
@@ -539,6 +551,8 @@ public class LiveTvService : IDisposable
 
         // Calculate EPG time range
         var now = DateTimeOffset.UtcNow;
+        // Keep programs that ended up to 1 hour ago
+        var pastGraceTime = now.AddHours(-1);
         var endTime = now.AddDays(config.EpgDaysToFetch);
 
         var tasks = channels.Select(async channel =>
@@ -564,7 +578,7 @@ public class LiveTvService : IDisposable
 
                 // Filter to our time range
                 return epgListings.Listings
-                    .Where(p => p.StopTimestamp > now.ToUnixTimeSeconds() && p.StartTimestamp < endTime.ToUnixTimeSeconds())
+                    .Where(p => p.StopTimestamp > pastGraceTime.ToUnixTimeSeconds() && p.StartTimestamp < endTime.ToUnixTimeSeconds())
                     .ToList();
             }
             catch (Exception ex)


### PR DESCRIPTION
- XMLTV Node Skipping Bug: The AppendUpstreamProgrammes method used an XmlReader
  loop that incorrectly advanced the reader twice when processing <programme> elements.
  This caused every second program to be skipped if the XMLTV file lacked whitespace
  between elements (common in minified IPTV data). If the "currently playing" show was
  the one skipped, it would be missing from the guide.
- Strict Timezone/Offset Parsing: The TryParseXmltvTime method failed to parse offsets
  containing colons (e.g., +02:00 instead of +0200). This resulted in programs being interpreted
  as UTC, causing them to be filtered out if the resulting UTC time appeared to be in the past.
- Aggressive Filtering: The EPG generation logic strictly filtered out any program that
  ended before the current UTC time. Any slight clock skew between the provider and the
  server, or minor timezone interpretation errors, would cause the current show to be dropped.

Changes Implemented

- Fixed XMLTV Parsing: Refactored the XmlReader loop in AppendUpstreamProgrammes to handle node
  advancement safely. It now correctly processes all elements even when no whitespace is present.
- Improved Time Parsing: Updated TryParseXmltvTime to:
    - Handle offsets with colons (e.g., +02:00).
    - Support more XMLTV date formats (YYYYMMDDHHMMSS, YYYYMMDDHHMM, and YYYYMMDD).
- Added 1-Hour Grace Period: Both the upstream XMLTV parsing and the per-channel JSON EPG fetch
  now include programs that ended up to 1 hour ago. This ensures currently playing shows are
  included even if there are minor time discrepancies.
- Unit Tests: Added a new test suite EpgParsingTests.cs to verify that various XMLTV time formats
  and offsets are now correctly parsed.

Co-authored-by: Google Gemini <gemini-code-assist@google.com>