### PR TITLE
Fix: duplicate series folders when TVDB ID lookup fails mid-sync

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -1182,4 +1182,71 @@ public class StrmSyncServiceTests
     }
 
     #endregion
+
+    #region BuildSeriesFolderName / BuildMovieFolderName Tests
+
+    [Fact]
+    public void BuildSeriesFolderName_WithTvdbId_IncludesTvdbSuffix()
+    {
+        var overrides = new Dictionary<string, int>();
+        var result = StrmSyncService.BuildSeriesFolderName("Test Series", 2024, overrides, providerTmdbId: null, autoLookupTvdbId: 12345);
+
+        result.Should().Be("Test Series (2024) [tvdbid-12345]");
+    }
+
+    [Fact]
+    public void BuildSeriesFolderName_WithProviderTmdbId_IncludesTmdbSuffix()
+    {
+        var overrides = new Dictionary<string, int>();
+        var result = StrmSyncService.BuildSeriesFolderName("Test Series", 2024, overrides, providerTmdbId: 67890, autoLookupTvdbId: null);
+
+        result.Should().Be("Test Series (2024) [tmdbid-67890]");
+    }
+
+    [Fact]
+    public void BuildSeriesFolderName_NoIds_ReturnsBaseName()
+    {
+        var overrides = new Dictionary<string, int>();
+        var result = StrmSyncService.BuildSeriesFolderName("Test Series", 2024, overrides, providerTmdbId: null, autoLookupTvdbId: null);
+
+        result.Should().Be("Test Series (2024)");
+    }
+
+    [Fact]
+    public void BuildSeriesFolderName_OverrideTakesPriority()
+    {
+        var overrides = new Dictionary<string, int> { ["Test Series (2024)"] = 999 };
+        var result = StrmSyncService.BuildSeriesFolderName("Test Series", 2024, overrides, providerTmdbId: 111, autoLookupTvdbId: 222);
+
+        result.Should().Be("Test Series (2024) [tvdbid-999]");
+    }
+
+    [Fact]
+    public void BuildMovieFolderName_WithTmdbId_IncludesTmdbSuffix()
+    {
+        var overrides = new Dictionary<string, int>();
+        var result = StrmSyncService.BuildMovieFolderName("Test Movie", 2024, overrides, providerTmdbId: 12345, autoLookupTmdbId: null);
+
+        result.Should().Be("Test Movie (2024) [tmdbid-12345]");
+    }
+
+    [Fact]
+    public void BuildMovieFolderName_NoIds_ReturnsBaseName()
+    {
+        var overrides = new Dictionary<string, int>();
+        var result = StrmSyncService.BuildMovieFolderName("Test Movie", 2024, overrides, providerTmdbId: null, autoLookupTmdbId: null);
+
+        result.Should().Be("Test Movie (2024)");
+    }
+
+    [Fact]
+    public void BuildMovieFolderName_OverrideTakesPriority()
+    {
+        var overrides = new Dictionary<string, int> { ["Test Movie (2024)"] = 999 };
+        var result = StrmSyncService.BuildMovieFolderName("Test Movie", 2024, overrides, providerTmdbId: 111, autoLookupTmdbId: 222);
+
+        result.Should().Be("Test Movie (2024) [tmdbid-999]");
+    }
+
+    #endregion
 }

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -2577,7 +2577,18 @@ public partial class StrmSyncService
                             string seriesBasePath = string.IsNullOrEmpty(targetFolder)
                                 ? seriesPath
                                 : Path.Combine(seriesPath, targetFolder);
-                            string seriesFolderPath = Path.Combine(seriesBasePath, seriesFolderName);
+                            // Resolve actual folder via seriesFolderLookup to handle suffix mismatch
+                            // (e.g. existing folder has [tvdbid-X] but lookup failed this sync)
+                            string seriesFolderPath;
+                            var lookupKey = seriesBasePath + "|" + baseName;
+                            if (seriesFolderLookup.TryGetValue(lookupKey, out var existingMatch))
+                            {
+                                seriesFolderPath = existingMatch.Path;
+                            }
+                            else
+                            {
+                                seriesFolderPath = Path.Combine(seriesBasePath, seriesFolderName);
+                            }
 
                             if (!Directory.Exists(seriesFolderPath))
                             {
@@ -2619,7 +2630,17 @@ public partial class StrmSyncService
                                 string seriesBasePath = string.IsNullOrEmpty(targetFolder)
                                     ? seriesPath
                                     : Path.Combine(seriesPath, targetFolder);
-                                string seriesFolderPath = Path.Combine(seriesBasePath, seriesFolderName);
+                                // Resolve actual folder via seriesFolderLookup to handle suffix mismatch
+                                string seriesFolderPath;
+                                var lookupKey = seriesBasePath + "|" + baseName;
+                                if (seriesFolderLookup.TryGetValue(lookupKey, out var existingMatch))
+                                {
+                                    seriesFolderPath = existingMatch.Path;
+                                }
+                                else
+                                {
+                                    seriesFolderPath = Path.Combine(seriesBasePath, seriesFolderName);
+                                }
 
                                 var existingStrms = directoryCache.GetOrAdd(
                                     seriesFolderPath,
@@ -2646,7 +2667,19 @@ public partial class StrmSyncService
                         string seriesBasePath = string.IsNullOrEmpty(targetFolder)
                             ? seriesPath
                             : Path.Combine(seriesPath, targetFolder);
-                        string seriesFolderPath = Path.Combine(seriesBasePath, seriesFolderName);
+                        // Resolve actual folder via seriesFolderLookup to handle suffix mismatch
+                        // (e.g. existing folder has [tvdbid-X] but lookup failed this sync)
+                        string seriesFolderPath;
+                        var lookupKey = seriesBasePath + "|" + baseName;
+                        if (seriesFolderLookup.TryGetValue(lookupKey, out var existingMatch))
+                        {
+                            seriesFolderPath = existingMatch.Path;
+                        }
+                        else
+                        {
+                            seriesFolderPath = Path.Combine(seriesBasePath, seriesFolderName);
+                        }
+
                         bool isNewSeries = !Directory.Exists(seriesFolderPath);
 
                         foreach (var seasonEntry in seriesInfo.Episodes)


### PR DESCRIPTION
When TVDB or TMDB lookups fail during a full series sync (rate limited, timeout, or no match), the plugin creates duplicate series folders. The new folder lacks the [tvdbid-X] or [tmdbid-X] suffix, while the original folder from a previous successful sync has it. Directory.Exists fails to match them, and a duplicate is created — explaining the jump from ~5500 to ~8300 series reported in the issue.

### Root cause

 returns the base name (e.g. "Series Name (2024)") when no ID is found, but the existing folder is named "Series Name (2024) [tvdbid-12345]". The SmartSkipExisting check and the main sync loop both constructed the folder path from the suffix-less name, never finding the existing folder via .

### Fix

Resolve the actual folder path through  (which keys by base name, stripped of any identifier suffix) before falling through to  or folder creation. Applied at all three sites where series folder paths are resolved.

### Tests

- All 492 tests pass (485 existing + 7 new)
- New tests cover BuildSeriesFolderName and BuildMovieFolderName suffix/fallback behavior for all three levels: TVDB ID, TMDB ID, manual override, and no-ID fallback
