### PR TITLE
feat: add tag support to channel overrides

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/ChannelOverrideParserTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/ChannelOverrideParserTests.cs
@@ -152,6 +152,57 @@ public class ChannelOverrideParserTests
         result.Should().HaveCount(2);
     }
 
+    [Fact]
+    public void Parse_ParsesTagsOnly()
+    {
+        var input = "987=|||sports,news,live";
+
+        var result = ChannelOverrideParser.Parse(input);
+
+        result.Should().ContainKey(987);
+        result[987].Name.Should().BeNull();
+        result[987].Number.Should().BeNull();
+        result[987].LogoUrl.Should().BeNull();
+        result[987].Tags.Should().BeEquivalentTo(new[] { "sports", "news", "live" });
+    }
+
+    [Fact]
+    public void Parse_ParsesAllFieldsWithTags()
+    {
+        var input = "555=ESPN|3|http://logo.com/e.png|sports,hd,live";
+
+        var result = ChannelOverrideParser.Parse(input);
+
+        result.Should().ContainKey(555);
+        result[555].Name.Should().Be("ESPN");
+        result[555].Number.Should().Be(3);
+        result[555].LogoUrl.Should().Be("http://logo.com/e.png");
+        result[555].Tags.Should().BeEquivalentTo(new[] { "sports", "hd", "live" });
+    }
+
+    [Fact]
+    public void Parse_TrimsTagWhitespace()
+    {
+        var input = "111=||| sports , hd , live ";
+
+        var result = ChannelOverrideParser.Parse(input);
+
+        result[111].Tags.Should().BeEquivalentTo(new[] { "sports", "hd", "live" });
+    }
+
+    [Fact]
+    public void Parse_HandlesEmptyTagField()
+    {
+        var input = "222=Name|1|logo.png|";
+
+        var result = ChannelOverrideParser.Parse(input);
+
+        result[222].Name.Should().Be("Name");
+        result[222].Number.Should().Be(1);
+        result[222].LogoUrl.Should().Be("logo.png");
+        result[222].Tags.Should().BeNull();
+    }
+
     #endregion
 
     #region ApplyOverride Tests
@@ -239,6 +290,40 @@ public class ChannelOverrideParserTests
         ChannelOverrideParser.ApplyOverride(channel, channelOverride);
 
         channel.Name.Should().Be("Original");
+    }
+
+    [Fact]
+    public void ApplyOverride_AppliesTagOverride()
+    {
+        var channel = new LiveStreamInfo { StreamId = 123, Name = "News", Num = 1 };
+        var channelOverride = new ChannelOverride { StreamId = 123, Tags = new[] { "news", "hd" } };
+
+        ChannelOverrideParser.ApplyOverride(channel, channelOverride);
+
+        channel.Tags.Should().BeEquivalentTo(new[] { "news", "hd" });
+    }
+
+    [Fact]
+    public void ApplyOverride_ClearsTagsWithEmptyArray()
+    {
+        var channel = new LiveStreamInfo { StreamId = 123, Name = "News", Tags = new[] { "old" } };
+        var channelOverride = new ChannelOverride { StreamId = 123, Tags = Array.Empty<string>() };
+
+        ChannelOverrideParser.ApplyOverride(channel, channelOverride);
+
+        channel.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyOverride_LeavesTagsUnchangedWhenNull()
+    {
+        var channel = new LiveStreamInfo { StreamId = 123, Name = "News", Tags = new[] { "existing" } };
+        var channelOverride = new ChannelOverride { StreamId = 123, Name = "Renamed" };
+
+        ChannelOverrideParser.ApplyOverride(channel, channelOverride);
+
+        channel.Name.Should().Be("Renamed");
+        channel.Tags.Should().BeEquivalentTo(new[] { "existing" }); // Unchanged
     }
 
     #endregion

--- a/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
+++ b/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
@@ -70,4 +70,11 @@ public class LiveStreamInfo
 
     [JsonProperty("stream_stats")]
     public StreamStatsInfo? StreamStats { get; set; }
+
+    /// <summary>
+    /// Gets or sets tags applied via channel overrides.
+    /// Not from the Xtream API — populated by the channel override system.
+    /// </summary>
+    [JsonIgnore]
+    public string[]? Tags { get; set; }
 }

--- a/Jellyfin.Xtream.Library/Service/ChannelOverride.cs
+++ b/Jellyfin.Xtream.Library/Service/ChannelOverride.cs
@@ -39,4 +39,11 @@ public class ChannelOverride
     /// Gets or sets the override logo URL (null means keep original).
     /// </summary>
     public string? LogoUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tags to apply to the channel (null means keep original).
+    /// Each entry is a single tag string; empty array means clear existing tags.
+    /// Tags are parsed from the 4th pipe-delimited field: comma-separated values.
+    /// </summary>
+    public string[]? Tags { get; set; }
 }

--- a/Jellyfin.Xtream.Library/Service/ChannelOverrideParser.cs
+++ b/Jellyfin.Xtream.Library/Service/ChannelOverrideParser.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Jellyfin.Xtream.Library.Client.Models;
 
 namespace Jellyfin.Xtream.Library.Service;
@@ -30,12 +31,13 @@ public static class ChannelOverrideParser
 
     /// <summary>
     /// Parses channel overrides from a newline-separated string.
-    /// Format: StreamId=Name|Number|LogoUrl
+    /// Format: StreamId=Name|Number|LogoUrl|Tags
     /// Examples:
     ///   123=BBC One                     (just rename)
     ///   456=CNN|2                       (rename + channel number)
     ///   789=Sky News|5|http://logo.png  (all fields)
-    ///   101=|10|                        (just channel number, keep original name).
+    ///   101=|10|                        (just channel number, keep original name)
+    ///   987=|||sports,news,live         (just tags, comma-separated).
     /// </summary>
     /// <param name="overridesText">Newline-separated list of overrides.</param>
     /// <returns>Dictionary mapping StreamId to ChannelOverride.</returns>
@@ -96,6 +98,17 @@ public static class ChannelOverrideParser
                 channelOverride.LogoUrl = parts[2].Trim();
             }
 
+            // Parse tags (fourth part, comma-separated)
+            if (parts.Length > 3 && !string.IsNullOrWhiteSpace(parts[3]))
+            {
+                channelOverride.Tags = parts[3]
+                    .Trim()
+                    .Split(',')
+                    .Select(t => t.Trim())
+                    .Where(t => !string.IsNullOrWhiteSpace(t))
+                    .ToArray();
+            }
+
             result[streamId] = channelOverride;
         }
 
@@ -127,6 +140,12 @@ public static class ChannelOverrideParser
         if (!string.IsNullOrEmpty(channelOverride.LogoUrl))
         {
             channel.StreamIcon = channelOverride.LogoUrl;
+        }
+
+        // Tags: null in the override means leave unchanged; non-null replaces (empty = clear).
+        if (channelOverride.Tags != null)
+        {
+            channel.Tags = channelOverride.Tags;
         }
     }
 }

--- a/Jellyfin.Xtream.Library/Service/Models/LiveChannelSnapshot.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/LiveChannelSnapshot.cs
@@ -149,6 +149,11 @@ public class LiveChannelSnapshotEntry
     public int Num { get; set; }
 
     /// <summary>
+    /// Gets or sets the channel tags from overrides.
+    /// </summary>
+    public string[]? Tags { get; set; }
+
+    /// <summary>
     /// Gets or sets the MD5 checksum of the tracked fields (used for change detection).
     /// </summary>
     public string Checksum { get; set; } = string.Empty;
@@ -169,13 +174,14 @@ public class LiveChannelSnapshotEntry
             EpgChannelId = channel.EpgChannelId ?? string.Empty,
             StreamIcon = channel.StreamIcon ?? string.Empty,
             Num = channel.Num,
+            Tags = channel.Tags,
             Checksum = ComputeChecksum(channel),
         };
     }
 
     /// <summary>
     /// Computes the change-detection checksum for a channel. Covers user-visible fields
-    /// (name, EPG id, logo, channel number) - other fields are intentionally excluded.
+    /// (name, EPG id, logo, channel number, tags) - other fields are intentionally excluded.
     /// </summary>
     /// <param name="channel">The live stream.</param>
     /// <returns>The MD5 checksum as a hex string.</returns>
@@ -184,12 +190,14 @@ public class LiveChannelSnapshotEntry
     {
         ArgumentNullException.ThrowIfNull(channel);
 
+        var tagsStr = channel.Tags != null ? string.Join(",", channel.Tags) : string.Empty;
         var data = string.Join(
             "|",
             channel.Name ?? string.Empty,
             channel.EpgChannelId ?? string.Empty,
             channel.StreamIcon ?? string.Empty,
-            channel.Num.ToString(CultureInfo.InvariantCulture));
+            channel.Num.ToString(CultureInfo.InvariantCulture),
+            tagsStr);
 
         var bytes = MD5.HashData(Encoding.UTF8.GetBytes(data));
         var sb = new StringBuilder(bytes.Length * 2);

--- a/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
+++ b/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
@@ -145,6 +145,7 @@ public class XtreamTunerHost : ITunerHost
                 ChannelGroup = channel.CategoryId is int catId && categoryNames.TryGetValue(catId, out var categoryName)
                     ? categoryName
                     : null,
+                Tags = channel.Tags,
             };
         }).ToList();
 


### PR DESCRIPTION
Adds tag support to Live TV channel overrides in the Channel Overrides config format.

**New format:** `StreamId=Name|Number|LogoUrl|Tags`

The 4th pipe-delimited field accepts comma-separated tags:
- `987=|||sports,news,live` — tags only
- `555=ESPN|3|http://logo.com/e.png|sports,hd,live` — all fields
- Empty 4th field leaves tags unchanged

Tags are propagated to `ChannelInfo.Tags`, which Jellyfin uses for access control (show/hide channels per user via tags).

**Changes:**
- `ChannelOverride`: new `Tags` property (`string[]?`)
- `ChannelOverrideParser.Parse`: comma-separated tag parsing from 4th field
- `ChannelOverrideParser.ApplyOverride`: applies tags to `LiveStreamInfo`
- `LiveStreamInfo`: new `Tags` field (internal passthrough, `[JsonIgnore]`)
- `XtreamTunerHost.GetChannels`: populates `ChannelInfo.Tags`
- `LiveChannelSnapshotEntry`: tracks tags in change-detection checksum
- 7 new tests covering parse + apply scenarios

**Tested:** `dotnet test -c Release` — 499 passed, 0 failed