### PR TITLE
feat: multi-provider Live TV support (#56)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/LiveTvServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/LiveTvServiceTests.cs
@@ -239,6 +239,41 @@ public class LiveTvServiceTests
         url.Should().NotContain("///");
     }
 
+    [Fact]
+    public void BuildStreamUrl_MultipleLiveTvProviders_UsesChannelProviderCredentials()
+    {
+        var config = new PluginConfiguration { LiveTvOutputFormat = "ts" };
+        config.Providers.Add(new ProviderConfig
+        {
+            BaseUrl = "http://provider-a.example.com",
+            Username = "user-a",
+            Password = "pass-a",
+        });
+        config.Providers.Add(new ProviderConfig
+        {
+            BaseUrl = "http://provider-b.example.com",
+            Username = "user-b",
+            Password = "pass-b",
+        });
+
+        var channel = new LiveStreamInfo { ProviderIndex = 1, StreamId = 2420044, Name = "X", Num = 1 };
+        var url = LiveTvService.BuildStreamUrl(config, channel);
+
+        url.Should().Be("http://provider-b.example.com/live/user-b/pass-b/2420044.ts");
+    }
+
+    [Fact]
+    public void BuildChannelId_ProviderZero_KeepsLegacyShape()
+    {
+        XtreamTunerHost.BuildChannelId(providerIndex: 0, streamId: 100).Should().Be("xtream_100");
+    }
+
+    [Fact]
+    public void BuildChannelId_AdditionalProvider_IncludesProviderIndex()
+    {
+        XtreamTunerHost.BuildChannelId(providerIndex: 1, streamId: 100).Should().Be("xtream_1_100");
+    }
+
     // BUG-011: Live TV channels appeared as one flat list because GenerateM3U never
     // emitted group-title. These pin the category grouping behaviour.
 

--- a/Jellyfin.Xtream.Library.Tests/Service/XtreamTunerHostTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/XtreamTunerHostTests.cs
@@ -382,6 +382,88 @@ public class XtreamTunerHostTests : IDisposable
     }
 
     [Fact]
+    public async Task GetChannelStreamMediaSources_AdditionalProviderChannel_UsesProviderCredentials()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.BaseUrl = string.Empty;
+        config.Username = string.Empty;
+        config.Password = string.Empty;
+        config.LiveTvOutputFormat = "ts";
+        config.Providers.Clear();
+        config.Providers.Add(new ProviderConfig
+        {
+            BaseUrl = "http://provider-a.example.com",
+            Username = "user-a",
+            Password = "pass-a",
+            IsEnabled = true,
+        });
+        config.Providers.Add(new ProviderConfig
+        {
+            BaseUrl = "http://provider-b.example.com",
+            Username = "user-b",
+            Password = "pass-b",
+            IsEnabled = true,
+        });
+
+        var result = await _tunerHost.GetChannelStreamMediaSources("xtream_1_100", CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].Path.Should().Be("http://provider-b.example.com/live/user-b/pass-b/100.ts");
+    }
+
+    [Fact]
+    public async Task GetChannels_DuplicateStreamIdsAcrossProviders_ReturnsUniqueChannelIds()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.EnableLiveTv = true;
+        config.EnableNativeTuner = true;
+        config.EnableChannelNameCleaning = false;
+        config.Providers.Clear();
+        config.Providers.Add(new ProviderConfig { BaseUrl = "http://provider-a.example.com", Username = "user-a", Password = "pass-a", IsEnabled = true });
+        config.Providers.Add(new ProviderConfig { BaseUrl = "http://provider-b.example.com", Username = "user-b", Password = "pass-b", IsEnabled = true });
+
+        _mockClient
+            .SetupSequence(c => c.GetAllLiveStreamsAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveStreamInfo> { new() { StreamId = 100, Name = "Provider A", Num = 1 } })
+            .ReturnsAsync(new List<LiveStreamInfo> { new() { StreamId = 100, Name = "Provider B", Num = 2 } });
+
+        var result = await _tunerHost.GetChannels(false, CancellationToken.None);
+
+        result.Select(c => c.Id).Should().Equal("xtream_100", "xtream_1_100");
+    }
+
+    [Fact]
+    public async Task GetChannelStream_WithHdhrPrefix_UsesMappedProviderCredentials()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.EnableLiveTv = true;
+        config.EnableNativeTuner = true;
+        config.EnableChannelNameCleaning = false;
+        config.LiveTvOutputFormat = "m3u8";
+        config.Providers.Clear();
+        config.Providers.Add(new ProviderConfig { BaseUrl = "http://provider-a.example.com", Username = "user-a", Password = "pass-a", IsEnabled = true });
+        config.Providers.Add(new ProviderConfig { BaseUrl = "http://provider-b.example.com", Username = "user-b", Password = "pass-b", IsEnabled = true });
+
+        _mockClient
+            .SetupSequence(c => c.GetAllLiveStreamsAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveStreamInfo> { new() { StreamId = 100, Name = "Provider A", Num = 1 } })
+            .ReturnsAsync(new List<LiveStreamInfo> { new() { StreamId = 200, Name = "Provider B", Num = 2 } });
+
+        await _tunerHost.GetChannels(false, CancellationToken.None);
+        _mockHttpClientFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient());
+
+        var result = await _tunerHost.GetChannelStream(
+            "hdhr_2",
+            string.Empty,
+            new List<MediaBrowser.Controller.Library.ILiveStream>(),
+            CancellationToken.None);
+
+        result.MediaSource.Path.Should().Be("http://provider-b.example.com/live/user-b/pass-b/200.m3u8");
+    }
+
+    [Fact]
     public async Task GetChannelStreamMediaSources_ReturnsEmpty_ForNonXtreamChannelId()
     {
         var result = await _tunerHost.GetChannelStreamMediaSources("m3u_016d53793ce443da", CancellationToken.None);

--- a/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
+++ b/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
@@ -77,4 +77,11 @@ public class LiveStreamInfo
     /// </summary>
     [JsonIgnore]
     public string[]? Tags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zero-based provider index this channel came from.
+    /// Not from the Xtream API - populated when Live TV merges multiple providers.
+    /// </summary>
+    [JsonIgnore]
+    public int ProviderIndex { get; set; }
 }

--- a/Jellyfin.Xtream.Library/Service/LiveTvService.cs
+++ b/Jellyfin.Xtream.Library/Service/LiveTvService.cs
@@ -316,9 +316,16 @@ public class LiveTvService : IDisposable
     /// <returns>A dictionary mapping category id to category name (empty on failure).</returns>
     internal async Task<Dictionary<int, string>> GetCategoryNameMapAsync(CancellationToken cancellationToken)
     {
+        var config = Plugin.Instance.Configuration;
+        var liveTvProviders = ResolveLiveTvProviders(config).ToList();
+        if (liveTvProviders.Count != 1)
+        {
+            return new Dictionary<int, string>();
+        }
+
         try
         {
-            var connectionInfo = Plugin.Instance.GetCreds(0);
+            var connectionInfo = Plugin.Instance.GetCreds(liveTvProviders[0].Index);
             var categories = await _client.GetLiveCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
             var map = new Dictionary<int, string>(categories.Count);
             foreach (var category in categories)
@@ -339,24 +346,42 @@ public class LiveTvService : IDisposable
     internal async Task<List<LiveStreamInfo>> GetFilteredChannelsAsync(CancellationToken cancellationToken)
     {
         var config = Plugin.Instance.Configuration;
-        var connectionInfo = Plugin.Instance.GetCreds(0);
+        var liveTvProviders = ResolveLiveTvProviders(config).ToList();
+        var allChannels = new List<LiveStreamInfo>();
 
-        List<LiveStreamInfo> allChannels;
+        foreach (var provider in liveTvProviders)
+        {
+            var connectionInfo = Plugin.Instance.GetCreds(provider.Index);
+            var providerChannels = await GetFilteredChannelsForProviderAsync(config, connectionInfo, provider.Index, cancellationToken).ConfigureAwait(false);
+            allChannels.AddRange(providerChannels);
+        }
+
+        _logger.LogInformation("Fetched {Count} Live TV channels from {ProviderCount} provider(s)", allChannels.Count, liveTvProviders.Count);
+        return allChannels;
+    }
+
+    private async Task<List<LiveStreamInfo>> GetFilteredChannelsForProviderAsync(
+        PluginConfiguration config,
+        ConnectionInfo connectionInfo,
+        int providerIndex,
+        CancellationToken cancellationToken)
+    {
+        List<LiveStreamInfo> providerChannels;
 
         var strategy = ChooseCategoryFetchStrategy(config.LiveChannelMode, config.SelectedLiveCategoryIds.Length);
         if (strategy == CategoryFetchStrategy.AllFromProvider)
         {
-            allChannels = await _client.GetAllLiveStreamsAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
+            providerChannels = await _client.GetAllLiveStreamsAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
         }
         else if (strategy == CategoryFetchStrategy.None)
         {
             // Custom mode + nothing selected = sync nothing. Headline fix vs pre-v1.35,
             // where this branch returned every channel from the provider.
-            allChannels = new List<LiveStreamInfo>();
+            providerChannels = new List<LiveStreamInfo>();
         }
         else
         {
-            allChannels = new List<LiveStreamInfo>();
+            providerChannels = new List<LiveStreamInfo>();
             using var semaphore = new SemaphoreSlim(config.EpgParallelism);
             var tasks = config.SelectedLiveCategoryIds.Select(async categoryId =>
             {
@@ -375,37 +400,37 @@ public class LiveTvService : IDisposable
             var results = await Task.WhenAll(tasks).ConfigureAwait(false);
             foreach (var result in results)
             {
-                allChannels.AddRange(result);
+                providerChannels.AddRange(result);
             }
 
-            // Remove duplicates by StreamId
-            allChannels = allChannels.GroupBy(c => c.StreamId).Select(g => g.First()).ToList();
+            // Remove duplicates by StreamId within each provider while allowing the same id across providers.
+            providerChannels = providerChannels.GroupBy(c => c.StreamId).Select(g => g.First()).ToList();
         }
 
         // Filter adult channels
         if (!config.IncludeAdultChannels)
         {
-            allChannels = allChannels.Where(c => !c.IsAdult).ToList();
+            providerChannels = providerChannels.Where(c => !c.IsAdult).ToList();
         }
 
         // Apply per-channel exclusions only in Custom mode (IncludeAll deliberately ignores them).
         if (config.LiveChannelMode == LiveChannelSelectionMode.Custom)
         {
-            allChannels = FilterExcludedChannels(allChannels, config.ExcludedLiveStreamIds);
+            providerChannels = FilterExcludedChannels(providerChannels, config.ExcludedLiveStreamIds);
         }
 
         // Apply channel overrides
         var overrides = ChannelOverrideParser.Parse(config.ChannelOverrides);
-        foreach (var channel in allChannels)
+        foreach (var channel in providerChannels)
         {
+            channel.ProviderIndex = providerIndex;
             if (overrides.TryGetValue(channel.StreamId, out var channelOverride))
             {
                 ChannelOverrideParser.ApplyOverride(channel, channelOverride);
             }
         }
 
-        _logger.LogInformation("Fetched {Count} Live TV channels", allChannels.Count);
-        return allChannels;
+        return providerChannels;
     }
 
     /// <summary>
@@ -509,7 +534,7 @@ public class LiveTvService : IDisposable
 
     internal static string BuildStreamUrl(PluginConfiguration config, LiveStreamInfo channel)
     {
-        var (baseUrl, username, password) = ResolveLiveTvProvider(config);
+        var (baseUrl, username, password) = ResolveLiveTvProvider(config, channel.ProviderIndex);
         var extension = string.Equals(config.LiveTvOutputFormat, "ts", StringComparison.OrdinalIgnoreCase) ? "ts" : "m3u8";
         return string.Create(CultureInfo.InvariantCulture, $"{baseUrl}/live/{username}/{password}/{channel.StreamId}.{extension}");
     }
@@ -521,22 +546,36 @@ public class LiveTvService : IDisposable
         // {start} = program start timestamp
         // {end} = program end timestamp
         // {duration} = duration in seconds
-        var (baseUrl, username, password) = ResolveLiveTvProvider(config);
+        var (baseUrl, username, password) = ResolveLiveTvProvider(config, channel.ProviderIndex);
         return string.Create(CultureInfo.InvariantCulture, $"{baseUrl}/timeshift/{username}/{password}/{{duration}}/{{start}}/{channel.StreamId}.ts");
     }
 
     // Resolves credentials for the Live TV provider. Reads Providers[0] when populated
     // (the multi-provider data model since v1.32), falling back to the legacy single-provider
     // fields for any pre-migration config still in flight. See BUG-008 in BUGS.md.
-    internal static (string BaseUrl, string Username, string Password) ResolveLiveTvProvider(PluginConfiguration config)
+    internal static (string BaseUrl, string Username, string Password) ResolveLiveTvProvider(PluginConfiguration config, int providerIndex = 0)
     {
-        var p = config.Providers.FirstOrDefault();
+        var p = config.Providers.ElementAtOrDefault(providerIndex) ?? config.Providers.FirstOrDefault();
         if (p != null && !string.IsNullOrEmpty(p.BaseUrl))
         {
             return (p.BaseUrl, p.Username, p.Password);
         }
 
         return (config.BaseUrl, config.Username, config.Password);
+    }
+
+    internal static IEnumerable<(int Index, ProviderConfig Provider)> ResolveLiveTvProviders(PluginConfiguration config)
+    {
+        for (var i = 0; i < config.Providers.Count; i++)
+        {
+            var provider = config.Providers[i];
+            if (provider.IsEnabled
+                && !string.IsNullOrEmpty(provider.BaseUrl)
+                && !string.IsNullOrEmpty(provider.Username))
+            {
+                yield return (i, provider);
+            }
+        }
     }
 
     private async Task<string> GenerateXmltvAsync(List<LiveStreamInfo> channels, PluginConfiguration config, string baseUrl, CancellationToken cancellationToken)
@@ -553,7 +592,7 @@ public class LiveTvService : IDisposable
                 config.ChannelRemoveTerms,
                 config.EnableChannelNameCleaning);
 
-            var channelId = XtreamTunerHost.ChannelIdPrefix + channel.StreamId.ToString(CultureInfo.InvariantCulture);
+            var channelId = XtreamTunerHost.BuildChannelId(channel.ProviderIndex, channel.StreamId);
 
             sb.Append(CultureInfo.InvariantCulture, $"  <channel id=\"{EscapeXml(channelId)}\">\n");
             sb.Append(CultureInfo.InvariantCulture, $"    <display-name>{EscapeXml(cleanName)}</display-name>\n");
@@ -569,15 +608,13 @@ public class LiveTvService : IDisposable
         // Fetch EPG data if enabled
         if (config.EnableEpg)
         {
-            var connectionInfo = Plugin.Instance.GetCreds(0);
-
-            // Build map: upstream epg_channel_id -> our xtream_{streamId} id
+            // Build map: upstream epg_channel_id -> our xtream_ id
             var idMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var ch in channels)
             {
                 if (!string.IsNullOrEmpty(ch.EpgChannelId))
                 {
-                    idMap[ch.EpgChannelId] = XtreamTunerHost.ChannelIdPrefix + ch.StreamId.ToString(CultureInfo.InvariantCulture);
+                    idMap[ch.EpgChannelId] = XtreamTunerHost.BuildChannelId(ch.ProviderIndex, ch.StreamId);
                 }
             }
 
@@ -586,7 +623,7 @@ public class LiveTvService : IDisposable
             var passthroughCount = 0;
             if (idMap.Count > 0)
             {
-                var upstreamXml = await _client.GetXmltvAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
+                var upstreamXml = await GetMergedXmltvAsync(channels, cancellationToken).ConfigureAwait(false);
                 if (!string.IsNullOrEmpty(upstreamXml))
                 {
                     passthroughCount = AppendUpstreamProgrammes(sb, upstreamXml, idMap, config, cancellationToken);
@@ -597,7 +634,7 @@ public class LiveTvService : IDisposable
             if (passthroughCount == 0)
             {
                 _logger.LogInformation("Upstream XMLTV unavailable or empty; falling back to per-channel JSON EPG");
-                var epgData = await FetchEpgDataAsync(channels, connectionInfo, config, cancellationToken).ConfigureAwait(false);
+                var epgData = await FetchEpgDataAsync(channels, config, cancellationToken).ConfigureAwait(false);
 
                 foreach (var program in epgData.OrderBy(p => p.StartTimestamp))
                 {
@@ -755,9 +792,24 @@ public class LiveTvService : IDisposable
         return true;
     }
 
+    private async Task<string?> GetMergedXmltvAsync(List<LiveStreamInfo> channels, CancellationToken cancellationToken)
+    {
+        var fragments = new List<string>();
+        foreach (var providerIndex in channels.Select(c => c.ProviderIndex).Distinct())
+        {
+            var connectionInfo = Plugin.Instance.GetCreds(providerIndex);
+            var xml = await _client.GetXmltvAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(xml))
+            {
+                fragments.Add(xml);
+            }
+        }
+
+        return fragments.Count == 0 ? null : string.Join('\n', fragments);
+    }
+
     private async Task<List<EpgProgram>> FetchEpgDataAsync(
         List<LiveStreamInfo> channels,
-        ConnectionInfo connectionInfo,
         PluginConfiguration config,
         CancellationToken cancellationToken)
     {
@@ -776,6 +828,7 @@ public class LiveTvService : IDisposable
             try
             {
                 // Use get_simple_data_table which returns more EPG data
+                var connectionInfo = Plugin.Instance.GetCreds(channel.ProviderIndex);
                 var epgListings = await _client.GetSimpleDataTableAsync(connectionInfo, channel.StreamId, cancellationToken).ConfigureAwait(false);
 
                 if (epgListings?.Listings == null)
@@ -784,7 +837,7 @@ public class LiveTvService : IDisposable
                 }
 
                 // Map channel ID to match the native tuner's xtream_ prefix
-                var channelId = XtreamTunerHost.ChannelIdPrefix + channel.StreamId.ToString(CultureInfo.InvariantCulture);
+                var channelId = XtreamTunerHost.BuildChannelId(channel.ProviderIndex, channel.StreamId);
 
                 foreach (var program in epgListings.Listings)
                 {

--- a/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
+++ b/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
@@ -53,8 +53,8 @@ public class XtreamTunerHost : ITunerHost
     private readonly LiveTvService _liveTvService;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<XtreamTunerHost> _logger;
-    private volatile Dictionary<string, int> _channelNumberToStreamId = new();
-    private volatile Dictionary<int, StreamStatsInfo> _streamStats = new();
+    private volatile Dictionary<string, string> _channelNumberToChannelId = new();
+    private volatile Dictionary<string, StreamStatsInfo> _streamStats = new();
     private List<ChannelInfo>? _cachedChannels;
     private DateTime _cacheTime = DateTime.MinValue;
 
@@ -105,27 +105,28 @@ public class XtreamTunerHost : ITunerHost
         var channels = await _liveTvService.GetFilteredChannelsAsync(cancellationToken).ConfigureAwait(false);
         var categoryNames = await _liveTvService.GetCategoryNameMapAsync(cancellationToken).ConfigureAwait(false);
 
-        var newMap = new Dictionary<string, int>(channels.Count);
-        var newStats = new Dictionary<int, StreamStatsInfo>(channels.Count);
+        var newMap = new Dictionary<string, string>(channels.Count);
+        var newStats = new Dictionary<string, StreamStatsInfo>(channels.Count);
         int statsCount = 0;
 
         var result = channels.Select(channel =>
         {
             var channelNumber = channel.Num.ToString(CultureInfo.InvariantCulture);
+            var channelId = BuildChannelId(channel.ProviderIndex, channel.StreamId);
 
-            if (!newMap.TryAdd(channelNumber, channel.StreamId))
+            if (!newMap.TryAdd(channelNumber, channelId))
             {
                 _logger.LogWarning(
-                    "Duplicate channel number {Num} — stream {OldStreamId} overwritten by {NewStreamId}",
+                    "Duplicate channel number {Num} - channel {OldChannelId} overwritten by {NewChannelId}",
                     channelNumber,
                     newMap[channelNumber],
-                    channel.StreamId);
-                newMap[channelNumber] = channel.StreamId;
+                    channelId);
+                newMap[channelNumber] = channelId;
             }
 
             if (channel.StreamStats != null)
             {
-                newStats[channel.StreamId] = channel.StreamStats;
+                newStats[channelId] = channel.StreamStats;
                 statsCount++;
             }
 
@@ -136,7 +137,7 @@ public class XtreamTunerHost : ITunerHost
 
             return new ChannelInfo
             {
-                Id = ChannelIdPrefix + channel.StreamId.ToString(CultureInfo.InvariantCulture),
+                Id = channelId,
                 Name = cleanName,
                 Number = channelNumber,
                 ImageUrl = _liveTvService.ResolveChannelLogoUrl(channel.StreamIcon, channel.StreamId),
@@ -149,7 +150,7 @@ public class XtreamTunerHost : ITunerHost
             };
         }).ToList();
 
-        _channelNumberToStreamId = newMap;
+        _channelNumberToChannelId = newMap;
         _streamStats = newStats;
         _cachedChannels = result;
         _cacheTime = DateTime.UtcNow;
@@ -163,17 +164,18 @@ public class XtreamTunerHost : ITunerHost
     {
         await EnsureChannelsLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!TryParseStreamId(channelId, out var streamId))
+        if (!TryParseChannelId(channelId, out var providerIndex, out var streamId))
         {
             return new List<MediaSourceInfo>();
         }
 
         var config = Plugin.Instance.Configuration;
-        var streamUrl = BuildStreamUrl(config, streamId);
-        _streamStats.TryGetValue(streamId, out var stats);
+        var streamUrl = BuildStreamUrl(config, providerIndex, streamId);
+        var canonicalChannelId = BuildChannelId(providerIndex, streamId);
+        _streamStats.TryGetValue(canonicalChannelId, out var stats);
         var isHls = !string.Equals(config.LiveTvOutputFormat, "ts", StringComparison.OrdinalIgnoreCase);
 
-        var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isHls, _logger);
+        var mediaSource = CreateMediaSourceInfo(canonicalChannelId, streamUrl, stats, isHls, _logger);
 
         return new List<MediaSourceInfo> { mediaSource };
     }
@@ -183,17 +185,18 @@ public class XtreamTunerHost : ITunerHost
     {
         await EnsureChannelsLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!TryParseStreamId(channelId, out var parsedStreamId))
+        if (!TryParseChannelId(channelId, out var providerIndex, out var parsedStreamId))
         {
             throw new System.IO.FileNotFoundException($"Channel {channelId} not found in Xtream tuner");
         }
 
         var config = Plugin.Instance.Configuration;
-        var streamUrl = BuildStreamUrl(config, parsedStreamId);
-        _streamStats.TryGetValue(parsedStreamId, out var stats);
+        var streamUrl = BuildStreamUrl(config, providerIndex, parsedStreamId);
+        var canonicalChannelId = BuildChannelId(providerIndex, parsedStreamId);
+        _streamStats.TryGetValue(canonicalChannelId, out var stats);
         var isHls = !string.Equals(config.LiveTvOutputFormat, "ts", StringComparison.OrdinalIgnoreCase);
 
-        var mediaSource = CreateMediaSourceInfo(parsedStreamId, streamUrl, stats, isHls, _logger);
+        var mediaSource = CreateMediaSourceInfo(canonicalChannelId, streamUrl, stats, isHls, _logger);
 
         var httpClient = _httpClientFactory.CreateClient();
         ILiveStream liveStream = new XtreamLiveStream(mediaSource, httpClient, _logger);
@@ -218,25 +221,35 @@ public class XtreamTunerHost : ITunerHost
         }
     }
 
-    private bool TryParseStreamId(string channelId, out int streamId)
+    private bool TryParseChannelId(string channelId, out int providerIndex, out int streamId)
     {
+        providerIndex = 0;
         streamId = 0;
 
-        // Our own prefix: xtream_<streamId>
+        // Our own prefixes: xtream_<streamId> for provider 0, xtream_<providerIndex>_<streamId> for others.
         if (channelId.StartsWith(ChannelIdPrefix, StringComparison.Ordinal))
         {
-            return int.TryParse(channelId.AsSpan(ChannelIdPrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out streamId);
+            var idPart = channelId.AsSpan(ChannelIdPrefix.Length);
+            var separator = idPart.IndexOf('_');
+            if (separator < 0)
+            {
+                return int.TryParse(idPart, NumberStyles.None, CultureInfo.InvariantCulture, out streamId);
+            }
+
+            return int.TryParse(idPart[..separator], NumberStyles.None, CultureInfo.InvariantCulture, out providerIndex)
+                && int.TryParse(idPart[(separator + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out streamId);
         }
 
         // Jellyfin remaps tuner channel IDs to hdhr_<channelNumber>
         if (channelId.StartsWith(JellyfinTunerPrefix, StringComparison.Ordinal))
         {
             var channelNumber = channelId.Substring(JellyfinTunerPrefix.Length);
-            var currentMap = _channelNumberToStreamId;
+            var currentMap = _channelNumberToChannelId;
 
-            if (currentMap.TryGetValue(channelNumber, out streamId))
+            if (currentMap.TryGetValue(channelNumber, out var mappedChannelId)
+                && TryParseChannelId(mappedChannelId, out providerIndex, out streamId))
             {
-                _logger.LogDebug("Resolved {ChannelId} via hdhr_ prefix to stream {StreamId}", channelId, streamId);
+                _logger.LogDebug("Resolved {ChannelId} via hdhr_ prefix to {MappedChannelId}", channelId, mappedChannelId);
                 return true;
             }
 
@@ -261,16 +274,23 @@ public class XtreamTunerHost : ITunerHost
         return false;
     }
 
-    private static string BuildStreamUrl(PluginConfiguration config, int streamId)
+    private static string BuildStreamUrl(PluginConfiguration config, int providerIndex, int streamId)
     {
-        var (baseUrl, username, password) = LiveTvService.ResolveLiveTvProvider(config);
+        var (baseUrl, username, password) = LiveTvService.ResolveLiveTvProvider(config, providerIndex);
         var extension = string.Equals(config.LiveTvOutputFormat, "ts", StringComparison.OrdinalIgnoreCase) ? "ts" : "m3u8";
         return string.Create(CultureInfo.InvariantCulture, $"{baseUrl}/live/{username}/{password}/{streamId}.{extension}");
     }
 
-    private static MediaSourceInfo CreateMediaSourceInfo(int streamId, string streamUrl, StreamStatsInfo? stats, bool isHls, ILogger logger)
+    internal static string BuildChannelId(int providerIndex, int streamId)
     {
-        var sourceId = "xtream_live_" + streamId.ToString(CultureInfo.InvariantCulture);
+        return providerIndex == 0
+            ? ChannelIdPrefix + streamId.ToString(CultureInfo.InvariantCulture)
+            : string.Create(CultureInfo.InvariantCulture, $"{ChannelIdPrefix}{providerIndex}_{streamId}");
+    }
+
+    private static MediaSourceInfo CreateMediaSourceInfo(string channelId, string streamUrl, StreamStatsInfo? stats, bool isHls, ILogger logger)
+    {
+        var sourceId = "xtream_live_" + channelId;
         bool hasStats = stats?.VideoCodec != null;
 
         var mediaSource = new MediaSourceInfo
@@ -335,8 +355,8 @@ public class XtreamTunerHost : ITunerHost
             mediaSource.MediaStreams = mediaStreams;
 
             logger.LogDebug(
-                "Stream {StreamId}: using stats — {VideoCodec} {Width}x{Height} @{Fps}fps, audio {AudioCodec}",
-                streamId,
+                "Channel {ChannelId}: using stats - {VideoCodec} {Width}x{Height} @{Fps}fps, audio {AudioCodec}",
+                channelId,
                 videoCodec,
                 width,
                 height,
@@ -363,7 +383,7 @@ public class XtreamTunerHost : ITunerHost
                     Index = 1,
                 },
             };
-            logger.LogDebug("Stream {StreamId}: no stats available, will probe", streamId);
+            logger.LogDebug("Channel {ChannelId}: no stats available, will probe", channelId);
         }
 
         return mediaSource;

--- a/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
+++ b/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
@@ -109,7 +109,8 @@ public class XtreamTunerHost : ITunerHost
         var newStats = new Dictionary<string, StreamStatsInfo>(channels.Count);
         int statsCount = 0;
 
-        var result = channels.Select(channel =>
+        var result = new List<ChannelInfo>(channels.Count);
+        foreach (var channel in channels)
         {
             var channelNumber = channel.Num.ToString(CultureInfo.InvariantCulture);
             var channelId = BuildChannelId(channel.ProviderIndex, channel.StreamId);
@@ -135,7 +136,7 @@ public class XtreamTunerHost : ITunerHost
                 config.ChannelRemoveTerms,
                 config.EnableChannelNameCleaning);
 
-            return new ChannelInfo
+            result.Add(new ChannelInfo
             {
                 Id = channelId,
                 Name = cleanName,
@@ -147,8 +148,8 @@ public class XtreamTunerHost : ITunerHost
                     ? categoryName
                     : null,
                 Tags = channel.Tags,
-            };
-        }).ToList();
+            });
+        }
 
         _channelNumberToChannelId = newMap;
         _streamStats = newStats;


### PR DESCRIPTION
This adds multi-provider support for Live TV, matching what VOD and Series already do.

What changed:
- Live TV channel fetching now iterates all enabled providers instead of only provider 0.
- Each channel carries its provider index, so stream URLs, catch-up URLs, JSON EPG fetches, and XMLTV IDs use the right credentials.
- Provider 0 keeps the legacy channel ID shape, while later providers use provider-scoped IDs to avoid stream ID collisions.
- XMLTV passthrough and JSON EPG fallback now merge data across providers.

Tests:
- Added coverage for multi-provider credential routing, duplicate stream IDs across providers, HDHR prefix resolution, and channel ID parsing.
- Local `dotnet build -c Release --no-restore` passes.
- Local `dotnet test -c Release --no-restore --verbosity minimal` passes: 505/505.

Closes [#56](https://github.com/firestaerter3/Jellyfin-Xtream-Library/issues/56)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live TV now supports multiple configured providers, with channels and guide data kept distinct per provider.
  * Channel IDs now include provider information when needed, helping avoid conflicts between identical stream IDs.

* **Bug Fixes**
  * Stream and catch-up playback now use the correct provider credentials for each channel.
  * Fixed channel mapping issues where duplicate stream IDs could cause the wrong channel to open.
  * XMLTV and channel lookups now work correctly across multiple providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->