### PR TITLE
Fix missing series STRM repair during incremental sync

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -1086,6 +1086,75 @@ public class StrmSyncServiceTests
 
     #endregion
 
+    #region HasCompleteExistingSeriesFolders Tests
+
+    [Fact]
+    public void HasCompleteExistingSeriesFolders_SuffixFolderWithEnoughStrms_ReturnsTrue()
+    {
+        var seriesPath = Path.Combine(Path.GetTempPath(), "Series");
+        var folderLookup = new Dictionary<string, (string Path, int Count)>(StringComparer.OrdinalIgnoreCase)
+        {
+            [seriesPath + "|Zoey 101"] = (Path.Combine(seriesPath, "Zoey 101 [tmdbid-1778]"), 4),
+        };
+
+        var result = StrmSyncService.HasCompleteExistingSeriesFolders(
+            seriesPath,
+            "Zoey 101",
+            new[] { 1 },
+            new Dictionary<int, List<string>>(),
+            folderLookup,
+            expectedEpisodeCount: 4);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasCompleteExistingSeriesFolders_SuffixFolderWithNoStrms_ReturnsFalse()
+    {
+        var seriesPath = Path.Combine(Path.GetTempPath(), "Series");
+        var folderLookup = new Dictionary<string, (string Path, int Count)>(StringComparer.OrdinalIgnoreCase)
+        {
+            [seriesPath + "|Zoey 101"] = (Path.Combine(seriesPath, "Zoey 101 [tmdbid-1778]"), 0),
+        };
+
+        var result = StrmSyncService.HasCompleteExistingSeriesFolders(
+            seriesPath,
+            "Zoey 101",
+            new[] { 1 },
+            new Dictionary<int, List<string>>(),
+            folderLookup,
+            expectedEpisodeCount: 1);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasCompleteExistingSeriesFolders_MappedFolderMissingStrms_ReturnsFalse()
+    {
+        var seriesPath = Path.Combine(Path.GetTempPath(), "Series");
+        var kidsPath = Path.Combine(seriesPath, "Kids");
+        var folderMappings = new Dictionary<int, List<string>>
+        {
+            [5] = new List<string> { "Kids" },
+        };
+        var folderLookup = new Dictionary<string, (string Path, int Count)>(StringComparer.OrdinalIgnoreCase)
+        {
+            [kidsPath + "|Zoey 101"] = (Path.Combine(kidsPath, "Zoey 101 [tmdbid-1778]"), 0),
+        };
+
+        var result = StrmSyncService.HasCompleteExistingSeriesFolders(
+            seriesPath,
+            "Zoey 101",
+            new[] { 5 },
+            folderMappings,
+            folderLookup,
+            expectedEpisodeCount: 3);
+
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
     #region SanitizeFileName Empty Brackets Tests
 
     [Fact]

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -2218,8 +2218,21 @@ public partial class StrmSyncService
                         var checksum = SnapshotService.CalculateChecksum(s.Series, prev.EpisodeCount);
                         if (prev.Checksum == checksum)
                         {
-                            unchangedSeries.Add(s);
-                            return false; // Unchanged
+                            string seriesName = SanitizeFileName(s.Series.Name, provider.CustomTitleRemoveTerms);
+                            int? year = ExtractYear(s.Series.Name);
+                            string baseName = year.HasValue ? $"{seriesName} ({year})" : seriesName;
+
+                            if (HasCompleteExistingSeriesFolders(seriesPath, baseName, s.CategoryIds, folderMappings, seriesFolderLookup, prev.EpisodeCount))
+                            {
+                                unchangedSeries.Add(s);
+                                return false; // Unchanged and locally complete
+                            }
+
+                            _logger.LogInformation(
+                                "Incremental sync: repairing series {SeriesName} ({SeriesId}) because local STRM files are missing (expected at least {ExpectedCount})",
+                                s.Series.Name,
+                                s.Series.SeriesId,
+                                prev.EpisodeCount);
                         }
                     }
 
@@ -2233,22 +2246,7 @@ public partial class StrmSyncService
                     int? year = ExtractYear(s.Series.Name);
                     string baseName = year.HasValue ? $"{seriesName} ({year})" : seriesName;
 
-                    var targetFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var categoryId in s.CategoryIds)
-                    {
-                        if (folderMappings.TryGetValue(categoryId, out var mappedFolders))
-                        {
-                            foreach (var folder in mappedFolders)
-                            {
-                                targetFolders.Add(folder);
-                            }
-                        }
-                    }
-
-                    if (targetFolders.Count == 0)
-                    {
-                        targetFolders.Add(string.Empty);
-                    }
+                    var targetFolders = BuildSeriesTargetFolders(s.CategoryIds, folderMappings);
 
                     foreach (var targetFolder in targetFolders)
                     {
@@ -2925,6 +2923,59 @@ public partial class StrmSyncService
         }
 
         return TruncateFileNameToFsLimit(ApplyFileNameRegexPatterns(fileName, regexRemovalPatterns));
+    }
+
+    internal static bool HasCompleteExistingSeriesFolders(
+        string seriesPath,
+        string baseName,
+        IEnumerable<int> categoryIds,
+        Dictionary<int, List<string>> folderMappings,
+        Dictionary<string, (string Path, int Count)> seriesFolderLookup,
+        int expectedEpisodeCount)
+    {
+        if (expectedEpisodeCount <= 0)
+        {
+            return true;
+        }
+
+        foreach (var targetFolder in BuildSeriesTargetFolders(categoryIds, folderMappings))
+        {
+            string seriesBasePath = string.IsNullOrEmpty(targetFolder)
+                ? seriesPath
+                : Path.Combine(seriesPath, targetFolder);
+            var lookupKey = seriesBasePath + "|" + baseName;
+            if (!seriesFolderLookup.TryGetValue(lookupKey, out var match) ||
+                match.Count < expectedEpisodeCount)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static HashSet<string> BuildSeriesTargetFolders(
+        IEnumerable<int> categoryIds,
+        Dictionary<int, List<string>> folderMappings)
+    {
+        var targetFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var categoryId in categoryIds)
+        {
+            if (folderMappings.TryGetValue(categoryId, out var mappedFolders))
+            {
+                foreach (var folder in mappedFolders)
+                {
+                    targetFolders.Add(folder);
+                }
+            }
+        }
+
+        if (targetFolders.Count == 0)
+        {
+            targetFolders.Add(string.Empty);
+        }
+
+        return targetFolders;
     }
 
     internal static string SanitizeFileName(string? name, string? customRemoveTerms = null)


### PR DESCRIPTION
Fixes [#64](https://github.com/firestaerter3/Jellyfin-Xtream-Library/issues/64).

## What changed
- Incremental series sync now verifies unchanged snapshot entries against the local `.strm` count before skipping them.
- Existing folders with only seasons/posters/NFO, including folders with `[tmdbid-...]` or `[tvdbid-...]` suffixes, stay in the repair path so episode `.strm` files can be written.
- Reused the series target-folder mapping logic for unchanged-series orphan protection.

## Tests
- `dotnet build -c Release`
- `dotnet test -c Release` (502/502 passing)
