### PR TITLE
feat: version-tag stripping, Include/Exclude category modes, and OrphanSafetyThreshold in the UI

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/CategorySelectionFilterTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/CategorySelectionFilterTests.cs
@@ -1,0 +1,140 @@
+// Copyright (C) 2024  Roland Breitschaft
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System.Linq;
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Service;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class CategorySelectionFilterTests
+{
+    // Stand-in for what the provider returns; the filter only ever looks at the IDs.
+    private static readonly int[] ProviderCategories = [10, 20, 30, 40];
+
+    private static int[] Apply(int[]? selectedIds, string? mode)
+    {
+        var set = CategorySelectionFilter.BuildSet(selectedIds);
+        bool exclude = CategorySelectionFilter.IsExcludeMode(mode);
+        return ProviderCategories
+            .Where(id => CategorySelectionFilter.ShouldSync(set, id, exclude))
+            .ToArray();
+    }
+
+    [Theory]
+    [InlineData("Exclude", true)]
+    [InlineData("exclude", true)]
+    [InlineData("EXCLUDE", true)]
+    [InlineData("Include", false)]
+    [InlineData("include", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("something else", false)]
+    public void IsExcludeMode_OnlyExcludeInverts(string? mode, bool expected)
+    {
+        CategorySelectionFilter.IsExcludeMode(mode).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildSet_NullOrEmpty_ReturnsEmpty()
+    {
+        CategorySelectionFilter.BuildSet(null).Should().BeEmpty();
+        CategorySelectionFilter.BuildSet([]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildSet_Duplicates_AreCollapsed()
+    {
+        CategorySelectionFilter.BuildSet([7, 7, 9]).Should().BeEquivalentTo([7, 9]);
+    }
+
+    // The four rows of the behaviour matrix agreed on GitHub #76.
+
+    [Fact]
+    public void IncludeMode_NothingSelected_SyncsEverything()
+    {
+        Apply([], "Include").Should().Equal(ProviderCategories);
+    }
+
+    [Fact]
+    public void IncludeMode_CategoriesSelected_SyncsOnlyThose()
+    {
+        Apply([20, 40], "Include").Should().Equal(20, 40);
+    }
+
+    [Fact]
+    public void ExcludeMode_NothingSelected_SyncsEverything()
+    {
+        // Excluding nothing excludes nothing. This is the row that was written down backwards
+        // in the first #76 reply and corrected afterwards.
+        Apply([], "Exclude").Should().Equal(ProviderCategories);
+    }
+
+    [Fact]
+    public void ExcludeMode_CategoriesSelected_SyncsEverythingElse()
+    {
+        Apply([20, 40], "Exclude").Should().Equal(10, 30);
+    }
+
+    // The point of the feature: a category the provider adds after the user configured their
+    // exclusions is synced automatically, without the user touching the settings again.
+    [Fact]
+    public void ExcludeMode_CategoryAddedByProviderLater_IsSyncedAutomatically()
+    {
+        var set = CategorySelectionFilter.BuildSet([20, 40]);
+        bool exclude = CategorySelectionFilter.IsExcludeMode("Exclude");
+
+        CategorySelectionFilter.ShouldSync(set, 99, exclude).Should().BeTrue();
+    }
+
+    // Same scenario under Include, which is the behaviour Exclude mode exists to avoid.
+    [Fact]
+    public void IncludeMode_CategoryAddedByProviderLater_IsNotSynced()
+    {
+        var set = CategorySelectionFilter.BuildSet([20, 40]);
+        bool exclude = CategorySelectionFilter.IsExcludeMode("Include");
+
+        CategorySelectionFilter.ShouldSync(set, 99, exclude).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExcludeMode_AllCategoriesSelected_SyncsNothing()
+    {
+        Apply(ProviderCategories, "Exclude").Should().BeEmpty();
+    }
+
+    // A config written before the mode setting existed has no mode at all. It has to keep
+    // behaving exactly as it did, which is Include.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void MissingMode_BehavesAsInclude(string? mode)
+    {
+        Apply([20, 40], mode).Should().Equal(20, 40);
+    }
+
+    [Fact]
+    public void ShouldSync_SelectionReferencesUnknownCategory_DoesNotAffectOthers()
+    {
+        // 999 is not on the provider. Include mode narrows to the one ID that does exist.
+        Apply([20, 999], "Include").Should().Equal(20);
+
+        // Exclude mode drops the one that exists and keeps the rest.
+        Apply([20, 999], "Exclude").Should().Equal(10, 30, 40);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(new int[0], false)]
+    [InlineData(new[] { 1 }, true)]
+    [InlineData(new[] { 1, 2 }, true)]
+    public void NarrowsSelection_OnlyTrueWhenSomethingIsConfigured(int[]? selectedIds, bool expected)
+    {
+        CategorySelectionFilter.NarrowsSelection(selectedIds).Should().Be(expected);
+    }
+}

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -198,6 +198,30 @@ public class StrmSyncServiceTests
     }
 
     [Theory]
+    [InlineData("Movie V1", "Movie")]
+    [InlineData("Movie [V2]", "Movie")]
+    [InlineData("Movie v3", "Movie")]
+    [InlineData("Movie V1 HEVC 4K", "Movie")]
+    [InlineData("AV1", "Unknown")] // AV1 is a codec, stripped by CodecTagPattern before VersionTagPattern runs
+    public void SanitizeFileName_VersionTags_RemovesThem(string input, string expected)
+    {
+        var result = StrmSyncService.SanitizeFileName(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Movie V1", "V1")]
+    [InlineData("Movie [V2] HEVC", "V2 HEVC")]
+    [InlineData("AV1", "AV1")] // codec match wins; VersionTagPattern \bV does not match inside "AV1"
+    public void ExtractVersionLabel_VersionTags_ReturnsThem(string input, string expected)
+    {
+        var result = StrmSyncService.ExtractVersionLabel(input);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("Movie BluRay", "Movie")]
     [InlineData("Movie Blu-Ray", "Movie")]
     [InlineData("Movie WEBRip", "Movie")]

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -212,7 +212,7 @@ public class StrmSyncServiceTests
 
     [Theory]
     [InlineData("Movie V1", "V1")]
-    [InlineData("Movie [V2] HEVC", "V2 HEVC")]
+    [InlineData("Movie [V2] HEVC", "HEVC V2")]
     [InlineData("AV1", "AV1")] // codec match wins; VersionTagPattern \bV does not match inside "AV1"
     public void ExtractVersionLabel_VersionTags_ReturnsThem(string input, string expected)
     {

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -210,15 +210,57 @@ public class StrmSyncServiceTests
         result.Should().Be(expected);
     }
 
+    // The version pattern is anchored to the end of the name, so a title that legitimately
+    // starts with a V-plus-digit token keeps its name instead of being reduced to "Unknown".
+    [Theory]
+    [InlineData("V2", "V2")]
+    [InlineData("V2: Escape from Hell", "V2 - Escape from Hell")]
+    [InlineData("V1: Hitler's Vengeance Weapon", "V1 - Hitler's Vengeance Weapon")]
+    [InlineData("V2 (2021)", "V2")]
+    public void SanitizeFileName_VersionTagIsTheTitle_KeepsIt(string input, string expected)
+    {
+        var result = StrmSyncService.SanitizeFileName(input);
+
+        result.Should().Be(expected);
+    }
+
+    // The point of stripping the tag: every variant of the same title has to collapse to one
+    // folder name so Jellyfin shows a single movie with a version dropdown (issue #74).
+    [Theory]
+    [InlineData("Final Destination Bloodlines (2025) - [V1]")]
+    [InlineData("Final Destination Bloodlines (2025) - [V2]")]
+    [InlineData("Final Destination Bloodlines (2025) - [4K]")]
+    [InlineData("Final Destination Bloodlines (2025) - [FHD]")]
+    public void SanitizeFileName_VersionAndQualityVariants_ShareOneFolderName(string input)
+    {
+        var result = StrmSyncService.SanitizeFileName(input);
+
+        result.Should().Be("Final Destination Bloodlines (2025)");
+    }
+
     [Theory]
     [InlineData("Movie V1", "V1")]
     [InlineData("Movie [V2] HEVC", "HEVC V2")]
     [InlineData("AV1", "AV1")]
+    [InlineData("Movie V1 HEVC 4K", "HEVC 4K V1")]
+    [InlineData("Final Destination Bloodlines (2025) - [V2]", "V2")]
     public void ExtractVersionLabel_VersionTags_ReturnsThem(string input, string expected)
     {
         var result = StrmSyncService.ExtractVersionLabel(input);
 
         result.Should().Be(expected);
+    }
+
+    // A name that is nothing but a version token is a real title, so it must not also be
+    // reported as a version label - otherwise the file lands as "V2 - V2.strm".
+    [Theory]
+    [InlineData("V2")]
+    [InlineData("V2: Escape from Hell")]
+    public void ExtractVersionLabel_VersionTagIsTheTitle_ReturnsNull(string input)
+    {
+        var result = StrmSyncService.ExtractVersionLabel(input);
+
+        result.Should().BeNull();
     }
 
     [Theory]

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -217,6 +217,12 @@ public class StrmSyncServiceTests
     [InlineData("V2: Escape from Hell", "V2 - Escape from Hell")]
     [InlineData("V1: Hitler's Vengeance Weapon", "V1 - Hitler's Vengeance Weapon")]
     [InlineData("V2 (2021)", "V2")]
+    [InlineData("V2 [4K]", "V2")]
+    [InlineData("V2 (4K)", "V2")]
+    // Bracketed and nothing else: the leftover after stripping is "[]", which is not whitespace,
+    // so the guard has to normalise empty brackets away before it decides.
+    [InlineData("[V2]", "[V2]")]
+    [InlineData("(V2)", "(V2)")]
     public void SanitizeFileName_VersionTagIsTheTitle_KeepsIt(string input, string expected)
     {
         var result = StrmSyncService.SanitizeFileName(input);
@@ -256,6 +262,8 @@ public class StrmSyncServiceTests
     [Theory]
     [InlineData("V2")]
     [InlineData("V2: Escape from Hell")]
+    [InlineData("[V2]")]
+    [InlineData("(V2)")]
     public void ExtractVersionLabel_VersionTagIsTheTitle_ReturnsNull(string input)
     {
         var result = StrmSyncService.ExtractVersionLabel(input);

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmSyncServiceTests.cs
@@ -202,7 +202,7 @@ public class StrmSyncServiceTests
     [InlineData("Movie [V2]", "Movie")]
     [InlineData("Movie v3", "Movie")]
     [InlineData("Movie V1 HEVC 4K", "Movie")]
-    [InlineData("AV1", "Unknown")] // AV1 is a codec, stripped by CodecTagPattern before VersionTagPattern runs
+    [InlineData("AV1", "Unknown")]
     public void SanitizeFileName_VersionTags_RemovesThem(string input, string expected)
     {
         var result = StrmSyncService.SanitizeFileName(input);
@@ -213,7 +213,7 @@ public class StrmSyncServiceTests
     [Theory]
     [InlineData("Movie V1", "V1")]
     [InlineData("Movie [V2] HEVC", "HEVC V2")]
-    [InlineData("AV1", "AV1")] // codec match wins; VersionTagPattern \bV does not match inside "AV1"
+    [InlineData("AV1", "AV1")]
     public void ExtractVersionLabel_VersionTags_ReturnsThem(string input, string expected)
     {
         var result = StrmSyncService.ExtractVersionLabel(input);

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -730,8 +730,17 @@
 
                         <div class="verticalSection">
                             <h3 class="sectionTitle">Movie Categories</h3>
-                            <div class="fieldDescription" id="vodCategoryDescription">
-                                Select specific categories to sync. Leave all unchecked to sync all categories.
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="selMovieCategoriesMode">Categories Mode</label>
+                                <select is="emby-select" id="selMovieCategoriesMode" name="MovieCategoriesMode">
+                                    <option value="Include">Include</option>
+                                    <option value="Exclude">Exclude</option>
+                                </select>
+                                <div class="fieldDescription">
+                                    Include: Select specific categories to sync.<br/>
+                                    Exclude: Select categories to exclude from syncing.<br/>
+                                    Leave all unchecked to sync all categories.
+                                </div>
                             </div>
                             <div>
                                 <button is="emby-button" type="button" id="btnLoadVodCategories" class="raised button-submit">
@@ -813,8 +822,17 @@
 
                         <div class="verticalSection">
                             <h3 class="sectionTitle">Series Categories</h3>
-                            <div class="fieldDescription" id="seriesCategoryDescription">
-                                Select specific categories to sync. Leave all unchecked to sync all categories.
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="selSeriesCategoriesMode">Categories Mode</label>
+                                <select is="emby-select" id="selSeriesCategoriesMode" name="SeriesCategoriesMode">
+                                    <option value="Include">Include</option>
+                                    <option value="Exclude">Exclude</option>
+                                </select>
+                                <div class="fieldDescription">
+                                    Include: Select specific categories to sync.<br/>
+                                    Exclude: Select categories to exclude from syncing.<br/>
+                                    Leave all unchecked to sync all categories.
+                                </div>
                             </div>
                             <div>
                                 <button is="emby-button" type="button" id="btnLoadSeriesCategories" class="raised button-submit">

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -730,7 +730,7 @@
 
                         <div class="verticalSection">
                             <h3 class="sectionTitle">Movie Categories</h3>
-                            <div class="inputContainer">
+                            <div class="inputContainer" id="movieCategoriesModeContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="selMovieCategoriesMode">Categories Mode</label>
                                 <select is="emby-select" id="selMovieCategoriesMode" name="MovieCategoriesMode">
                                     <option value="Include">Include</option>
@@ -822,7 +822,7 @@
 
                         <div class="verticalSection">
                             <h3 class="sectionTitle">Series Categories</h3>
-                            <div class="inputContainer">
+                            <div class="inputContainer"  id="seriesCategoriesModeContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="selSeriesCategoriesMode">Categories Mode</label>
                                 <select is="emby-select" id="selSeriesCategoriesMode" name="SeriesCategoriesMode">
                                     <option value="Include">Include</option>

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -405,6 +405,15 @@
                                     Remove STRM files for content that no longer exists on the provider.
                                 </div>
                             </div>
+                            <div id="orphanSafetyThresholdSettings" class="inputContainer" style="display: none;">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOrphanSafetyThreshold">Orphan Safety Threshold (%)</label>
+                                <input is="emby-input" type="number" id="txtOrphanSafetyThreshold" name="OrphanSafetyThreshold"
+                                       min="0" max="100" step="5" />
+                                <div class="fieldDescription">
+                                    Skip orphan cleanup if more than this percentage of existing content would be
+                                    deleted, as a protection against provider glitches (0-100%). Default: 20%.
+                                </div>
+                            </div>
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
                                     <input is="emby-checkbox" type="checkbox" id="chkEnableMetadataLookup" name="EnableMetadataLookup" />

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -207,6 +207,7 @@ const XtreamLibraryConfig = {
             p.MovieFolderMappings = '';
         } else {
             this.updateFolderDefinitionsFromUI('vod');
+            p.MovieCategoriesMode = 'Include';
             p.SelectedVodCategoryIds = this.getAllCategoryIdsFromFolders('vod');
             p.MovieFolderMappings = this.buildFolderMappings(this.vodFolderDefinitions);
         }
@@ -216,6 +217,7 @@ const XtreamLibraryConfig = {
             p.SeriesFolderMappings = '';
         } else {
             this.updateFolderDefinitionsFromUI('series');
+            p.SeriesCategoriesMode = 'Include';
             p.SelectedSeriesCategoryIds = this.getAllCategoryIdsFromFolders('series');
             p.SeriesFolderMappings = this.buildFolderMappings(this.seriesFolderDefinitions);
         }

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -132,7 +132,7 @@ const XtreamLibraryConfig = {
 
         document.getElementById('selMovieFolderMode').value = p.MovieFolderMode || 'Single';
         document.getElementById('selSeriesFolderMode').value = p.SeriesFolderMode || 'Single';
-        
+
         document.getElementById('selMovieCategoriesMode').value = p.MovieCategoriesMode || 'Include';
         document.getElementById('selSeriesCategoriesMode').value = p.SeriesCategoriesMode || 'Include';
 

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -498,6 +498,7 @@ const XtreamLibraryConfig = {
     // Update visibility based on folder mode
     updateFolderModeVisibility: function (type) {
         var modeSelect = document.getElementById(type === 'vod' ? 'selMovieFolderMode' : 'selSeriesFolderMode');
+        var categoriesModeSection = document.getElementById(type === 'vod' ? 'movieCategoriesModeContainer' : 'seriesCategoriesModeContainer');
         var singleSection = document.getElementById(type === 'vod' ? 'vodSingleFolderSection' : 'seriesSingleFolderSection');
         var multiSection = document.getElementById(type === 'vod' ? 'vodMultiFolderSection' : 'seriesMultiFolderSection');
 
@@ -505,10 +506,12 @@ const XtreamLibraryConfig = {
 
         if (mode === 'Multiple') {
             singleSection.style.display = 'none';
+            categoriesModeSection.style.display = 'none';
             multiSection.style.display = 'block';
             this.renderFolderList(type);
         } else {
             singleSection.style.display = 'block';
+            categoriesModeSection.style.display = 'block';
             multiSection.style.display = 'none';
         }
     },

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -57,6 +57,8 @@ const XtreamLibraryConfig = {
             ExcludedSeriesIds: [],
             MovieFolderMode: 'Single',
             SeriesFolderMode: 'Single',
+            MovieCategoriesMode: 'Include',
+            SeriesCategoriesMode: 'Include',
             MovieFolderMappings: '',
             SeriesFolderMappings: '',
             TmdbFolderIdOverrides: '',
@@ -128,6 +130,9 @@ const XtreamLibraryConfig = {
 
         document.getElementById('selMovieFolderMode').value = p.MovieFolderMode || 'Single';
         document.getElementById('selSeriesFolderMode').value = p.SeriesFolderMode || 'Single';
+        
+        document.getElementById('selMovieCategoriesMode').value = p.MovieCategoriesMode || 'Include';
+        document.getElementById('selSeriesCategoriesMode').value = p.SeriesCategoriesMode || 'Include';
 
         self.vodFolderDefinitions = self.parseFolderMappings(p.MovieFolderMappings);
         self.seriesFolderDefinitions = self.parseFolderMappings(p.SeriesFolderMappings);
@@ -188,6 +193,9 @@ const XtreamLibraryConfig = {
         p.SyncMovies = document.getElementById('chkSyncMovies').checked;
         p.SyncSeries = document.getElementById('chkSyncSeries').checked;
         p.CleanupOrphans = document.getElementById('chkCleanupOrphans').checked;
+
+        p.MovieCategoriesMode = document.getElementById('selMovieCategoriesMode').value;
+        p.SeriesCategoriesMode = document.getElementById('selSeriesCategoriesMode').value;
 
         var movieMode = document.getElementById('selMovieFolderMode').value;
         var seriesMode = document.getElementById('selSeriesFolderMode').value;

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -210,9 +210,15 @@ const XtreamLibraryConfig = {
             p.SelectedVodCategoryIds = this.getSelectedCategoryIds('vod');
             p.MovieFolderMappings = '';
         } else {
+            // Multiple folder mode. SelectedVodCategoryIds is the only thing the sync consults to
+            // decide *whether* a category is synced (StrmSyncService.SyncMoviesAsync); the folder
+            // mappings only decide *where* the files land. It therefore has to carry the union of
+            // the categories assigned to folders - reading the flat checkbox list here yields an
+            // empty array (that list is hidden, and often never rendered, in this mode), and an
+            // empty array means "sync every category on the provider".
             this.updateFolderDefinitionsFromUI('vod');
             p.MovieCategoriesMode = 'Include';
-            p.SelectedVodCategoryIds = this.getSelectedCategoryIds('vod');
+            p.SelectedVodCategoryIds = this.getAllCategoryIdsFromFolders('vod');
             p.MovieFolderMappings = this.buildFolderMappings(this.vodFolderDefinitions);
         }
 
@@ -220,9 +226,11 @@ const XtreamLibraryConfig = {
             p.SelectedSeriesCategoryIds = this.getSelectedCategoryIds('series');
             p.SeriesFolderMappings = '';
         } else {
+            // Same as movies above: the union of the folder-assigned categories, not the hidden
+            // flat checkbox list.
             this.updateFolderDefinitionsFromUI('series');
             p.SeriesCategoriesMode = 'Include';
-            p.SelectedSeriesCategoryIds = this.getSelectedCategoryIds('series');
+            p.SelectedSeriesCategoryIds = this.getAllCategoryIdsFromFolders('series');
             p.SeriesFolderMappings = this.buildFolderMappings(this.seriesFolderDefinitions);
         }
 

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -500,19 +500,16 @@ const XtreamLibraryConfig = {
         var modeSelect = document.getElementById(type === 'vod' ? 'selMovieFolderMode' : 'selSeriesFolderMode');
         var singleSection = document.getElementById(type === 'vod' ? 'vodSingleFolderSection' : 'seriesSingleFolderSection');
         var multiSection = document.getElementById(type === 'vod' ? 'vodMultiFolderSection' : 'seriesMultiFolderSection');
-        var descElem = document.getElementById(type === 'vod' ? 'vodCategoryDescription' : 'seriesCategoryDescription');
 
         var mode = modeSelect.value;
 
         if (mode === 'Multiple') {
             singleSection.style.display = 'none';
             multiSection.style.display = 'block';
-            descElem.textContent = 'Create folders and assign categories to each. Categories can be in multiple folders.';
             this.renderFolderList(type);
         } else {
             singleSection.style.display = 'block';
             multiSection.style.display = 'none';
-            descElem.textContent = 'Select specific categories to sync. Leave all unchecked to sync all categories.';
         }
     },
 

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -117,7 +117,7 @@ const XtreamLibraryConfig = {
         document.getElementById('chkSyncMovies').checked = p.SyncMovies !== false;
         document.getElementById('chkSyncSeries').checked = p.SyncSeries !== false;
         document.getElementById('chkCleanupOrphans').checked = p.CleanupOrphans !== false;
-        document.getElementById('txtOrphanSafetyThreshold').value = Math.round((p.OrphanSafetyThreshold || 0.20) * 100);
+        document.getElementById('txtOrphanSafetyThreshold').value = Math.round((p.OrphanSafetyThreshold != null ? p.OrphanSafetyThreshold : 0.20) * 100);
         self.updateOrphanSafetyThresholdVisibility();
 
         self.selectedVodCategoryIds = p.SelectedVodCategoryIds || [];
@@ -195,7 +195,8 @@ const XtreamLibraryConfig = {
         p.SyncMovies = document.getElementById('chkSyncMovies').checked;
         p.SyncSeries = document.getElementById('chkSyncSeries').checked;
         p.CleanupOrphans = document.getElementById('chkCleanupOrphans').checked;
-        p.OrphanSafetyThreshold = (parseInt(document.getElementById('txtOrphanSafetyThreshold').value) || 20) / 100;
+        var orphanSafetyThresholdValue = parseInt(document.getElementById('txtOrphanSafetyThreshold').value);
+        p.OrphanSafetyThreshold = (isNaN(orphanSafetyThresholdValue) ? 20 : orphanSafetyThresholdValue) / 100;
 
         p.MovieCategoriesMode = document.getElementById('selMovieCategoriesMode').value;
         p.SeriesCategoriesMode = document.getElementById('selSeriesCategoriesMode').value;

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -75,7 +75,7 @@ const XtreamLibraryConfig = {
             FullSyncIntervalDays: 7,
             FullSyncChangeThreshold: 0.5,
             CleanupOrphans: true,
-            OrphanSafetyThreshold: 0.5,
+            OrphanSafetyThreshold: 0.2,
             SmartSkipExisting: true,
             SyncParallelism: 10,
             CategoryBatchSize: 25,
@@ -117,6 +117,8 @@ const XtreamLibraryConfig = {
         document.getElementById('chkSyncMovies').checked = p.SyncMovies !== false;
         document.getElementById('chkSyncSeries').checked = p.SyncSeries !== false;
         document.getElementById('chkCleanupOrphans').checked = p.CleanupOrphans !== false;
+        document.getElementById('txtOrphanSafetyThreshold').value = Math.round((p.OrphanSafetyThreshold || 0.20) * 100);
+        self.updateOrphanSafetyThresholdVisibility();
 
         self.selectedVodCategoryIds = p.SelectedVodCategoryIds || [];
         self.selectedSeriesCategoryIds = p.SelectedSeriesCategoryIds || [];
@@ -193,6 +195,7 @@ const XtreamLibraryConfig = {
         p.SyncMovies = document.getElementById('chkSyncMovies').checked;
         p.SyncSeries = document.getElementById('chkSyncSeries').checked;
         p.CleanupOrphans = document.getElementById('chkCleanupOrphans').checked;
+        p.OrphanSafetyThreshold = (parseInt(document.getElementById('txtOrphanSafetyThreshold').value) || 20) / 100;
 
         p.MovieCategoriesMode = document.getElementById('selMovieCategoriesMode').value;
         p.SeriesCategoriesMode = document.getElementById('selSeriesCategoriesMode').value;
@@ -1669,6 +1672,11 @@ const XtreamLibraryConfig = {
         document.getElementById('dispatcharrSettings').style.display = enabled ? 'block' : 'none';
     },
 
+    updateOrphanSafetyThresholdVisibility: function () {
+        const enabled = document.getElementById('chkCleanupOrphans').checked;
+        document.getElementById('orphanSafetyThresholdSettings').style.display = enabled ? 'block' : 'none';
+    },
+
     testDispatcharr: function () {
         const statusSpan = document.getElementById('dispatcharrStatus');
         statusSpan.innerHTML = '<span style="color: orange;">Testing...</span>';
@@ -2328,6 +2336,13 @@ function initXtreamLibraryConfig() {
     if (chkEnableDispatcharrMode) {
         chkEnableDispatcharrMode.addEventListener('change', function () {
             XtreamLibraryConfig.updateDispatcharrVisibility();
+        });
+    }
+
+    var chkCleanupOrphans = document.getElementById('chkCleanupOrphans');
+    if (chkCleanupOrphans) {
+        chkCleanupOrphans.addEventListener('change', function () {
+            XtreamLibraryConfig.updateOrphanSafetyThresholdVisibility();
         });
     }
 

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -212,7 +212,7 @@ const XtreamLibraryConfig = {
         } else {
             this.updateFolderDefinitionsFromUI('vod');
             p.MovieCategoriesMode = 'Include';
-            p.SelectedVodCategoryIds = this.getAllCategoryIdsFromFolders('vod');
+            p.SelectedVodCategoryIds = this.getSelectedCategoryIds('vod');
             p.MovieFolderMappings = this.buildFolderMappings(this.vodFolderDefinitions);
         }
 
@@ -222,7 +222,7 @@ const XtreamLibraryConfig = {
         } else {
             this.updateFolderDefinitionsFromUI('series');
             p.SeriesCategoriesMode = 'Include';
-            p.SelectedSeriesCategoryIds = this.getAllCategoryIdsFromFolders('series');
+            p.SelectedSeriesCategoryIds = this.getSelectedCategoryIds('series');
             p.SeriesFolderMappings = this.buildFolderMappings(this.seriesFolderDefinitions);
         }
 

--- a/Jellyfin.Xtream.Library/ProviderConfig.cs
+++ b/Jellyfin.Xtream.Library/ProviderConfig.cs
@@ -80,6 +80,20 @@ public class ProviderConfig
     public bool SyncSeries { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the movie categories sync mode.
+    /// "Include" = Select specific categories to sync.
+    /// "Exclude" = Select categories to exclude from syncing.
+    /// </summary>
+    public string MovieCategoriesMode { get; set; } = "Include";
+
+    /// <summary>
+    /// Gets or sets the series categories sync mode.
+    /// "Include" = Select specific categories to sync.
+    /// "Exclude" = Select categories to exclude from syncing.
+    /// </summary>
+    public string SeriesCategoriesMode { get; set; } = "Include";
+
+    /// <summary>
     /// Gets or sets the array of selected VOD category IDs to sync.
     /// Empty array means sync all categories.
     /// </summary>

--- a/Jellyfin.Xtream.Library/Service/CategorySelectionFilter.cs
+++ b/Jellyfin.Xtream.Library/Service/CategorySelectionFilter.cs
@@ -1,0 +1,91 @@
+// Copyright (C) 2024  Roland Breitschaft
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Xtream.Library.Service;
+
+/// <summary>
+/// Decides which provider categories take part in a sync, given the per-provider selection
+/// (<see cref="Jellyfin.Xtream.Library.ProviderConfig.SelectedVodCategoryIds"/> /
+/// <see cref="Jellyfin.Xtream.Library.ProviderConfig.SelectedSeriesCategoryIds"/>) and the mode
+/// (<see cref="Jellyfin.Xtream.Library.ProviderConfig.MovieCategoriesMode"/> /
+/// <see cref="Jellyfin.Xtream.Library.ProviderConfig.SeriesCategoriesMode"/>).
+/// <para>
+/// The agreed behaviour (GitHub #76) is:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Include, nothing selected: sync everything.</description></item>
+/// <item><description>Include, categories selected: sync only those.</description></item>
+/// <item><description>Exclude, nothing selected: sync everything (excluding nothing excludes nothing).</description></item>
+/// <item><description>Exclude, categories selected: sync everything except those, so categories the
+/// provider adds later are picked up automatically.</description></item>
+/// </list>
+/// </summary>
+internal static class CategorySelectionFilter
+{
+    /// <summary>
+    /// The mode value that inverts the selection. Any other value, including null and the
+    /// empty string, is treated as Include so that configs written before the mode existed
+    /// keep their original behaviour.
+    /// </summary>
+    public const string ExcludeMode = "Exclude";
+
+    /// <summary>
+    /// Returns true when the configured mode means "exclude the selected categories".
+    /// </summary>
+    /// <param name="mode">The configured mode, may be null on configs predating the setting.</param>
+    /// <returns>True for Exclude, false for anything else.</returns>
+    public static bool IsExcludeMode(string? mode)
+        => string.Equals(mode, ExcludeMode, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Builds a lookup set from a selection array. Null or empty input yields an empty set.
+    /// </summary>
+    /// <param name="selectedIds">The configured category IDs, may be null.</param>
+    /// <returns>A hash set of the selected IDs.</returns>
+    public static HashSet<int> BuildSet(int[]? selectedIds)
+    {
+        if (selectedIds == null || selectedIds.Length == 0)
+        {
+            return new HashSet<int>();
+        }
+
+        return new HashSet<int>(selectedIds);
+    }
+
+    /// <summary>
+    /// Returns true when the given category should take part in the sync.
+    /// An empty selection means "sync everything" in both modes.
+    /// </summary>
+    /// <param name="selectedSet">The selection set from <see cref="BuildSet"/>.</param>
+    /// <param name="categoryId">The provider category ID to test.</param>
+    /// <param name="exclude">True when the selection is an exclusion list, see <see cref="IsExcludeMode"/>.</param>
+    /// <returns>True if the category should be synced.</returns>
+    public static bool ShouldSync(HashSet<int> selectedSet, int categoryId, bool exclude)
+    {
+        ArgumentNullException.ThrowIfNull(selectedSet);
+
+        if (selectedSet.Count == 0)
+        {
+            return true;
+        }
+
+        return exclude ? !selectedSet.Contains(categoryId) : selectedSet.Contains(categoryId);
+    }
+
+    /// <summary>
+    /// Returns true when the selection actually narrows the catalogue down. This is false when
+    /// nothing is selected, because then every category is in scope and callers that only make
+    /// sense on a reduced set (such as the name-based series retry) should not run at all.
+    /// </summary>
+    /// <param name="selectedIds">The configured category IDs, may be null.</param>
+    /// <returns>True if at least one category ID is configured.</returns>
+    public static bool NarrowsSelection(int[]? selectedIds)
+        => selectedIds != null && selectedIds.Length > 0;
+}

--- a/Jellyfin.Xtream.Library/Service/SnapshotService.cs
+++ b/Jellyfin.Xtream.Library/Service/SnapshotService.cs
@@ -102,6 +102,8 @@ public class SnapshotService : IDisposable
             provider.SeriesFolderMode,
             provider.MovieFolderMappings ?? string.Empty,
             provider.SeriesFolderMappings ?? string.Empty,
+            provider.MovieCategoriesMode,
+            provider.SeriesCategoriesMode,
             string.Join(",", provider.SelectedVodCategoryIds?.OrderBy(id => id) ?? Enumerable.Empty<int>()),
             string.Join(",", provider.SelectedSeriesCategoryIds?.OrderBy(id => id) ?? Enumerable.Empty<int>()),
             string.Join(",", provider.ExcludedVodStreamIds?.OrderBy(id => id) ?? Enumerable.Empty<int>()),

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -501,24 +501,30 @@ public partial class StrmSyncService
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
-        var allSeriesCategories = await _client.GetSeriesCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
         var selectedIds = provider.SelectedSeriesCategoryIds;
-        var categoryIds = allSeriesCategories.Select(c => c.CategoryId).ToArray();
 
-        if (selectedIds != null && selectedIds.Length > 0)
-        {
-            var selectedIdSet = selectedIds.ToHashSet();
-            bool exclude = string.Equals(provider.SeriesCategoriesMode, "Exclude", StringComparison.OrdinalIgnoreCase);
-            categoryIds = allSeriesCategories
-                .Where(c => exclude ? !selectedIdSet.Contains(c.CategoryId) : selectedIdSet.Contains(c.CategoryId))
-                .Select(c => c.CategoryId)
-                .ToArray();
-        }
-
-        // If no categories selected, we can't search efficiently
-        if (categoryIds == null || categoryIds.Length == 0)
+        // This is the fallback path after a lookup has already failed, and it costs one
+        // GetSeriesByCategoryAsync call per category it walks. Only a selection that actually
+        // narrows the catalogue makes that worth doing: with nothing configured every category is
+        // in scope, and scanning all of them would hammer a provider that is already misbehaving.
+        // Bailing out here also keeps the GetSeriesCategoryAsync call below off the common path.
+        if (!CategorySelectionFilter.NarrowsSelection(selectedIds))
         {
             _logger.LogDebug("No series categories configured, cannot search for series by name");
+            return null;
+        }
+
+        var allSeriesCategories = await _client.GetSeriesCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
+        var selectedIdSet = CategorySelectionFilter.BuildSet(selectedIds);
+        bool exclude = CategorySelectionFilter.IsExcludeMode(provider.SeriesCategoriesMode);
+        var categoryIds = allSeriesCategories
+            .Where(c => CategorySelectionFilter.ShouldSync(selectedIdSet, c.CategoryId, exclude))
+            .Select(c => c.CategoryId)
+            .ToArray();
+
+        if (categoryIds.Length == 0)
+        {
+            _logger.LogDebug("Series category selection resolves to nothing, cannot search for series by name");
             return null;
         }
 
@@ -1260,9 +1266,9 @@ public partial class StrmSyncService
         var selectedIds = provider.SelectedVodCategoryIds;
         if (selectedIds.Length > 0)
         {
-            var selectedIdSet = selectedIds.ToHashSet();
-            bool exclude = string.Equals(provider.MovieCategoriesMode, "Exclude", StringComparison.OrdinalIgnoreCase);
-            var filteredCategories = categories.Where(c => exclude ? !selectedIdSet.Contains(c.CategoryId) : selectedIdSet.Contains(c.CategoryId)).ToList();
+            var selectedIdSet = CategorySelectionFilter.BuildSet(selectedIds);
+            bool exclude = CategorySelectionFilter.IsExcludeMode(provider.MovieCategoriesMode);
+            var filteredCategories = categories.Where(c => CategorySelectionFilter.ShouldSync(selectedIdSet, c.CategoryId, exclude)).ToList();
             var skippedCount = categories.Count - filteredCategories.Count;
             if (skippedCount > 0)
             {
@@ -2007,9 +2013,9 @@ public partial class StrmSyncService
         var selectedIds = provider.SelectedSeriesCategoryIds;
         if (selectedIds.Length > 0)
         {
-            var selectedIdSet = selectedIds.ToHashSet();
-            bool exclude = string.Equals(provider.SeriesCategoriesMode, "Exclude", StringComparison.OrdinalIgnoreCase);
-            var filteredCategories = categories.Where(c => exclude ? !selectedIdSet.Contains(c.CategoryId) : selectedIdSet.Contains(c.CategoryId)).ToList();
+            var selectedIdSet = CategorySelectionFilter.BuildSet(selectedIds);
+            bool exclude = CategorySelectionFilter.IsExcludeMode(provider.SeriesCategoriesMode);
+            var filteredCategories = categories.Where(c => CategorySelectionFilter.ShouldSync(selectedIdSet, c.CategoryId, exclude)).ToList();
             var skippedCount = categories.Count - filteredCategories.Count;
             if (skippedCount > 0)
             {

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -1249,7 +1249,8 @@ public partial class StrmSyncService
         if (selectedIds.Length > 0)
         {
             var selectedIdSet = selectedIds.ToHashSet();
-            var filteredCategories = categories.Where(c => selectedIdSet.Contains(c.CategoryId)).ToList();
+            bool exclude = string.Equals(provider.MovieCategoriesMode, "Exclude", StringComparison.OrdinalIgnoreCase);
+            var filteredCategories = categories.Where(c => exclude ? !selectedIdSet.Contains(c.CategoryId) : selectedIdSet.Contains(c.CategoryId)).ToList();
             var skippedCount = categories.Count - filteredCategories.Count;
             if (skippedCount > 0)
             {
@@ -1995,7 +1996,8 @@ public partial class StrmSyncService
         if (selectedIds.Length > 0)
         {
             var selectedIdSet = selectedIds.ToHashSet();
-            var filteredCategories = categories.Where(c => selectedIdSet.Contains(c.CategoryId)).ToList();
+            bool exclude = string.Equals(provider.SeriesCategoriesMode, "Exclude", StringComparison.OrdinalIgnoreCase);
+            var filteredCategories = categories.Where(c => exclude ? !selectedIdSet.Contains(c.CategoryId) : selectedIdSet.Contains(c.CategoryId)).ToList();
             var skippedCount = categories.Count - filteredCategories.Count;
             if (skippedCount > 0)
             {

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -3032,8 +3032,13 @@ public partial class StrmSyncService
         // Remove source tags like "BluRay", "WEBRip", "HDTV", etc.
         cleanName = SourceTagPattern().Replace(cleanName, string.Empty);
 
-        // Remove generic version tags like "V1", "V2", "V3", etc.
-        cleanName = VersionTagPattern().Replace(cleanName, string.Empty);
+        // Remove trailing version tags like "V1", "V2", "V3", etc. A name that is nothing but a
+        // version token is a real title (the 2021 film "V2"), so it is kept as-is.
+        string withoutVersionTag = VersionTagPattern().Replace(cleanName, string.Empty);
+        if (!string.IsNullOrWhiteSpace(withoutVersionTag))
+        {
+            cleanName = withoutVersionTag;
+        }
 
         // Remove empty brackets left after tag stripping (e.g., "Movie [4K]" → "Movie []" → "Movie")
         cleanName = EmptyBracketsPattern().Replace(cleanName, string.Empty);
@@ -3077,24 +3082,39 @@ public partial class StrmSyncService
 
         var labels = new List<string>();
 
+        // Each tag is stripped after it is collected, mirroring the order SanitizeFileName uses.
+        // VersionTagPattern is anchored to the end of the name, so it cannot see the "V1" in
+        // "Movie V1 HEVC 4K" until "HEVC" and "4K" have been removed.
         foreach (Match match in CodecTagPattern().Matches(cleanName))
         {
             labels.Add(match.Value);
         }
+
+        cleanName = CodecTagPattern().Replace(cleanName, string.Empty);
 
         foreach (Match match in QualityTagPattern().Matches(cleanName))
         {
             labels.Add(match.Value);
         }
 
+        cleanName = QualityTagPattern().Replace(cleanName, string.Empty);
+
         foreach (Match match in SourceTagPattern().Matches(cleanName))
         {
             labels.Add(match.Value);
         }
 
-        foreach (Match match in VersionTagPattern().Matches(cleanName))
+        cleanName = SourceTagPattern().Replace(cleanName, string.Empty);
+
+        // Same guard as SanitizeFileName: a name that is nothing but a version token is a real
+        // title, not a version marker. Without this the name and the label disagree and the file
+        // ends up as "V2 - V2.strm".
+        if (!string.IsNullOrWhiteSpace(VersionTagPattern().Replace(cleanName, string.Empty)))
         {
-            labels.Add(match.Value);
+            foreach (Match match in VersionTagPattern().Matches(cleanName))
+            {
+                labels.Add(match.Value);
+            }
         }
 
         return labels.Count > 0 ? string.Join(" ", labels) : null;
@@ -3592,8 +3612,13 @@ public partial class StrmSyncService
     [GeneratedRegex(@"\b(?:Blu-?Ray|BRRip|BDRip|WEB-?(?:Rip|DL)?|HDTV|DVDRip|DVD|REMUX|CAM|TS|HC|PROPER|REPACK)\b", RegexOptions.IgnoreCase)]
     private static partial Regex SourceTagPattern();
 
-    // Matches generic numbered version tags like "V1", "V2", "V3", to mark duplicate/alternate streams.
-    [GeneratedRegex(@"\bV[0-9]+\b", RegexOptions.IgnoreCase)]
+    // Matches generic numbered version tags like "V1", "V2", "V3", used to mark duplicate/alternate
+    // streams. Anchored to the end of the name (optionally inside a closing bracket) so that real
+    // titles beginning with a V-plus-digit token - "V2", "V1: Hitler's Vengeance Weapon" - survive.
+    // Only the token itself is consumed, exactly like the codec/quality/source patterns, so the
+    // surrounding " - []" is cleaned up by EmptyBracketsPattern and a "[V1]" variant ends up with
+    // the same folder name as the "[4K]" variant of the same title.
+    [GeneratedRegex(@"\bV[0-9]+\b(?=\s*[\]\)]?\s*$)", RegexOptions.IgnoreCase)]
     private static partial Regex VersionTagPattern();
 
     // Fixes malformed quotes like "'\'" "\''" "'\''" "Bob'\''s" to just "'"

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -504,7 +504,6 @@ public partial class StrmSyncService
         var allSeriesCategories = await _client.GetSeriesCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
         var selectedIds = provider.SelectedSeriesCategoryIds;
         var categoryIds = allSeriesCategories.Select(c => c.CategoryId).ToArray();
-
         if (selectedIds != null && selectedIds.Length > 0)
         {
             var selectedIdSet = selectedIds.ToHashSet();

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -501,7 +501,19 @@ public partial class StrmSyncService
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
-        var categoryIds = provider.SelectedSeriesCategoryIds;
+        var allSeriesCategories = await _client.GetSeriesCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
+        var selectedIds = provider.SelectedSeriesCategoryIds;
+        var categoryIds = allSeriesCategories.Select(c => c.CategoryId).ToArray();
+        
+        if (selectedIds != null && selectedIds.Length > 0)
+        {
+            var selectedIdSet = selectedIds.ToHashSet();
+            bool exclude = string.Equals(provider.SeriesCategoriesMode, "Exclude", StringComparison.OrdinalIgnoreCase);
+            categoryIds = allSeriesCategories
+                .Where(c => exclude ? !selectedIdSet.Contains(c.CategoryId) : selectedIdSet.Contains(c.CategoryId))
+                .Select(c => c.CategoryId)
+                .ToArray();
+        }
 
         // If no categories selected, we can't search efficiently
         if (categoryIds == null || categoryIds.Length == 0)

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -504,7 +504,7 @@ public partial class StrmSyncService
         var allSeriesCategories = await _client.GetSeriesCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
         var selectedIds = provider.SelectedSeriesCategoryIds;
         var categoryIds = allSeriesCategories.Select(c => c.CategoryId).ToArray();
-        
+
         if (selectedIds != null && selectedIds.Length > 0)
         {
             var selectedIdSet = selectedIds.ToHashSet();

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -3018,6 +3018,9 @@ public partial class StrmSyncService
         // Remove source tags like "BluRay", "WEBRip", "HDTV", etc.
         cleanName = SourceTagPattern().Replace(cleanName, string.Empty);
 
+        // Remove generic version tags like "V1", "V2", "V3", etc.
+        cleanName = VersionTagPattern().Replace(cleanName, string.Empty);
+
         // Remove empty brackets left after tag stripping (e.g., "Movie [4K]" → "Movie []" → "Movie")
         cleanName = EmptyBracketsPattern().Replace(cleanName, string.Empty);
 
@@ -3071,6 +3074,11 @@ public partial class StrmSyncService
         }
 
         foreach (Match match in SourceTagPattern().Matches(cleanName))
+        {
+            labels.Add(match.Value);
+        }
+
+        foreach (Match match in VersionTagPattern().Matches(cleanName))
         {
             labels.Add(match.Value);
         }
@@ -3569,6 +3577,10 @@ public partial class StrmSyncService
     // Matches source tags like "BluRay", "BRRip", "WEBRip", "WEB-DL", "HDTV", "DVDRip", "REMUX", etc.
     [GeneratedRegex(@"\b(?:Blu-?Ray|BRRip|BDRip|WEB-?(?:Rip|DL)?|HDTV|DVDRip|DVD|REMUX|CAM|TS|HC|PROPER|REPACK)\b", RegexOptions.IgnoreCase)]
     private static partial Regex SourceTagPattern();
+
+    // Matches generic numbered version tags like "V1", "V2", "V3", to mark duplicate/alternate streams.
+    [GeneratedRegex(@"\bV[0-9]+\b", RegexOptions.IgnoreCase)]
+    private static partial Regex VersionTagPattern();
 
     // Fixes malformed quotes like "'\'" "\''" "'\''" "Bob'\''s" to just "'"
     [GeneratedRegex(@"'\\''|'\\'|\\''|''+")]

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -3039,9 +3039,11 @@ public partial class StrmSyncService
         cleanName = SourceTagPattern().Replace(cleanName, string.Empty);
 
         // Remove trailing version tags like "V1", "V2", "V3", etc. A name that is nothing but a
-        // version token is a real title (the 2021 film "V2"), so it is kept as-is.
+        // version token is a real title (the 2021 film "V2"), so it is kept as-is. The leftover is
+        // probed with the empty brackets already taken out, otherwise "[V2]" reads as the
+        // non-empty "[]" here, survives the guard, and is then wiped to "Unknown" two lines down.
         string withoutVersionTag = VersionTagPattern().Replace(cleanName, string.Empty);
-        if (!string.IsNullOrWhiteSpace(withoutVersionTag))
+        if (!string.IsNullOrWhiteSpace(EmptyBracketsPattern().Replace(withoutVersionTag, string.Empty)))
         {
             cleanName = withoutVersionTag;
         }
@@ -3112,10 +3114,11 @@ public partial class StrmSyncService
 
         cleanName = SourceTagPattern().Replace(cleanName, string.Empty);
 
-        // Same guard as SanitizeFileName: a name that is nothing but a version token is a real
-        // title, not a version marker. Without this the name and the label disagree and the file
-        // ends up as "V2 - V2.strm".
-        if (!string.IsNullOrWhiteSpace(VersionTagPattern().Replace(cleanName, string.Empty)))
+        // Same guard as SanitizeFileName, including the empty-bracket normalisation. Both have to
+        // reach the same verdict: if one strips the token and the other does not, the name and the
+        // label disagree and the file ends up as "V2 - V2.strm".
+        if (!string.IsNullOrWhiteSpace(
+            EmptyBracketsPattern().Replace(VersionTagPattern().Replace(cleanName, string.Empty), string.Empty)))
         {
             foreach (Match match in VersionTagPattern().Matches(cleanName))
             {

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -504,6 +504,7 @@ public partial class StrmSyncService
         var allSeriesCategories = await _client.GetSeriesCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
         var selectedIds = provider.SelectedSeriesCategoryIds;
         var categoryIds = allSeriesCategories.Select(c => c.CategoryId).ToArray();
+
         if (selectedIds != null && selectedIds.Length > 0)
         {
             var selectedIdSet = selectedIds.ToHashSet();


### PR DESCRIPTION
Added functionality to remove generic version tags from the cleaned name and updated the regex pattern for version tags.

https://github.com/firestaerter3/Jellyfin-Xtream-Library/issues/74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Include/Exclude modes for movie and series category filtering.
  * Added per-provider controls and descriptions for category behavior.
  * Category controls adapt to the selected folder configuration.
  * Added a safety threshold to prevent excessive orphaned-content cleanup.
  * Improved filename handling by preserving version labels such as V1, V2, and V3 while keeping base names clean.
* **Bug Fixes**
  * Corrected filtering when excluding configured movie or series categories.
  * Improved series category lookup across all available provider categories.
  * Configuration changes are now reliably recognized and saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->