### PR TITLE
fix(sync): stop one stream silently overwriting another's STRM file

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -240,6 +241,45 @@ public class StrmNameCollisionTests : IDisposable
         return await RunSyncAsync(syncMovies: false, syncSeries: true, useShippedDefaults: false).ConfigureAwait(true);
     }
 
+    // The claim set deliberately compares Ordinal. syncedFiles uses OrdinalIgnoreCase because
+    // erring towards "already known" protects files from orphan cleanup, but the same comparer
+    // here errs towards refusing a write, and on a case-sensitive filesystem two titles differing
+    // only in case are two legitimately distinct paths. Asserting on the collision count rather
+    // than the file count keeps this meaningful on case-insensitive filesystems too.
+    [Fact]
+    public async Task TitlesDifferingOnlyInCase_AreNotTreatedAsACollision()
+    {
+        var result = await RunMovieSyncAsync(
+            new StreamInfo { StreamId = 100, Name = "Case Movie (2024)", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "CASE MOVIE (2024)", ContainerExtension = "mp4" })
+            .ConfigureAwait(true);
+
+        result.MovieNameCollisions.Should().Be(0, "case differences are distinct paths, not a collision");
+        result.Errors.Should().Be(0);
+    }
+
+    // Providers are allowed to share a LibraryPath: PluginConfiguration records
+    // HasDuplicateLibraryPaths but nothing refuses the config. A per-provider claim set would let
+    // the second provider overwrite the first one's file with nothing counted.
+    [Fact]
+    public async Task TwoProvidersSharingALibraryPath_StillDetectTheCollision()
+    {
+        _client.Setup(c => c.GetVodCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Movies" } });
+        _client.Setup(c => c.GetVodStreamsByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StreamInfo>
+            {
+                new() { StreamId = 100, Name = "Shared Movie (2024)", ContainerExtension = "mp4" },
+            });
+
+        var result = await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults: false, providerCount: 2)
+            .ConfigureAwait(true);
+
+        result.MovieNameCollisions.Should().Be(1, "the second provider must not silently overwrite the first");
+        Directory.GetFiles(Path.Combine(_libraryPath, "Movies"), "*.strm", SearchOption.AllDirectories)
+            .Should().HaveCount(1);
+    }
+
     private Task<SyncResult> RunMovieSyncAsync(params StreamInfo[] streams)
         => RunMovieSyncAsync(streams, useShippedDefaults: false);
 
@@ -253,7 +293,10 @@ public class StrmNameCollisionTests : IDisposable
         return await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults).ConfigureAwait(true);
     }
 
-    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults)
+    private Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults)
+        => RunSyncAsync(syncMovies, syncSeries, useShippedDefaults, providerCount: 1);
+
+    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount)
     {
         var appPaths = new Mock<IServerApplicationPaths>();
         appPaths.Setup(p => p.PluginConfigurationsPath).Returns(_libraryPath);
@@ -265,24 +308,21 @@ public class StrmNameCollisionTests : IDisposable
 
         // Constructing the plugin publishes Plugin.Instance, which SyncAsync reads.
         var plugin = new Plugin(appPaths.Object, new RealXmlSerializer());
-        plugin.Configuration.Providers =
-        [
-            new ProviderConfig
-            {
-                Name = "test",
-                BaseUrl = "http://provider.test",
-                Username = "u",
-                Password = "p",
-                LibraryPath = _libraryPath,
-                SyncMovies = syncMovies,
-                SyncSeries = syncSeries,
-                CleanupOrphans = false,
-                EnableIncrementalSync = useShippedDefaults,
-                SmartSkipExisting = useShippedDefaults,
-                DownloadArtworkForUnmatched = false,
-                SyncParallelism = 1,
-            },
-        ];
+        plugin.Configuration.Providers = Enumerable.Range(0, providerCount).Select(i => new ProviderConfig
+        {
+            Name = $"test{i}",
+            BaseUrl = $"http://provider{i}.test",
+            Username = "u",
+            Password = "p",
+            LibraryPath = _libraryPath,
+            SyncMovies = syncMovies,
+            SyncSeries = syncSeries,
+            CleanupOrphans = false,
+            EnableIncrementalSync = useShippedDefaults,
+            SmartSkipExisting = useShippedDefaults,
+            DownloadArtworkForUnmatched = false,
+            SyncParallelism = 1,
+        }).ToList();
         plugin.Configuration.EnableLiveTv = false;
         plugin.Configuration.EnableMetadataLookup = false;
 

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
@@ -137,7 +137,123 @@ public class StrmNameCollisionTests : IDisposable
             .Should().HaveCount(1);
     }
 
-    private async Task<SyncResult> RunMovieSyncAsync(params StreamInfo[] streams)
+    // syncedFiles doubles as the orphan-protection set: the incremental and smart-skip paths bulk-add
+    // existing .strm files to it so cleanup leaves them alone. Both default to on, and the first
+    // version of this guard reused that dictionary as its collision detector, which would have made
+    // "this file exists" indistinguishable from "another stream wrote this". A stale URL would then
+    // never be refreshed. These runs use the shipped defaults, unlike the tests above.
+    [Fact]
+    public async Task DefaultConfigWithIncrementalAndSmartSkip_ReportsNoCollisionsForDistinctMovies()
+    {
+        StreamInfo[] Streams() =>
+        [
+            new StreamInfo { StreamId = 100, Name = "Alpha Movie (2024)", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "Beta Movie (2024)", ContainerExtension = "mp4" },
+        ];
+
+        var first = await RunMovieSyncAsync(Streams(), useShippedDefaults: true).ConfigureAwait(true);
+        first.MovieNameCollisions.Should().Be(0);
+        first.MoviesCreated.Should().Be(2);
+
+        // Second run over the same catalogue: the files now exist, so the skip and orphan-protection
+        // paths are the ones doing the work. Nothing here is a collision.
+        var second = await RunMovieSyncAsync(Streams(), useShippedDefaults: true).ConfigureAwait(true);
+        second.MovieNameCollisions.Should().Be(0, "an existing file is not another stream's claim");
+        second.MoviesCreated.Should().Be(0);
+
+        Directory.GetFiles(Path.Combine(_libraryPath, "Movies"), "*.strm", SearchOption.AllDirectories)
+            .Should().HaveCount(2);
+    }
+
+    // The guard sits in the write loop, immediately before the branch that rewrites a STRM whose
+    // URL no longer matches. If it treated "this file exists" as a collision, that rewrite would
+    // never happen and a provider URL change would leave the library pointing at a dead host.
+    [Fact]
+    public async Task DefaultConfig_ChangedProviderUrlIsStillRewritten()
+    {
+        var first = await RunMovieSyncAsync(
+            [new StreamInfo { StreamId = 100, Name = "Refresh Movie (2024)", ContainerExtension = "mp4" }],
+            useShippedDefaults: true).ConfigureAwait(true);
+        first.MoviesCreated.Should().Be(1);
+
+        var strm = Directory.GetFiles(Path.Combine(_libraryPath, "Movies"), "*.strm", SearchOption.AllDirectories).Single();
+        (await File.ReadAllTextAsync(strm).ConfigureAwait(true)).Should().EndWith("/100.mp4");
+
+        // Same movie, same name, different container. The URL changes, so the stream counts as
+        // modified and reaches the write loop, where the file already exists.
+        var second = await RunMovieSyncAsync(
+            [new StreamInfo { StreamId = 100, Name = "Refresh Movie (2024)", ContainerExtension = "mkv" }],
+            useShippedDefaults: true).ConfigureAwait(true);
+
+        second.MovieNameCollisions.Should().Be(0, "an existing file is not another stream's claim");
+        second.MoviesUpdated.Should().Be(1, "a changed provider URL still has to be rewritten");
+        (await File.ReadAllTextAsync(strm).ConfigureAwait(true)).Should().EndWith("/100.mkv");
+    }
+
+    // Episodes collide on series name plus season and episode number. The wiring is the same two
+    // hops as the movie counter (local -> provider result -> global result), and the movie one was
+    // missing its second hop while the guard itself worked, so this path needs its own run.
+    [Fact]
+    public async Task TwoEpisodesSharingSeasonAndEpisodeNumber_WriteOneFileAndCountTheCollision()
+    {
+        // The episode title is part of the file name, so a collision needs that to match too.
+        // Providers routinely send no title at all, which collapses both to "<series> - S01E01.strm".
+        var result = await RunSeriesSyncAsync(
+            new Episode { EpisodeId = 11, EpisodeNum = 1, Season = 1, Title = string.Empty, ContainerExtension = "mkv" },
+            new Episode { EpisodeId = 22, EpisodeNum = 1, Season = 1, Title = string.Empty, ContainerExtension = "mkv" })
+            .ConfigureAwait(true);
+
+        result.EpisodeNameCollisions.Should().Be(1);
+        result.Errors.Should().Be(0);
+        Directory.GetFiles(Path.Combine(_libraryPath, "Series"), "*.strm", SearchOption.AllDirectories)
+            .Should().HaveCount(1);
+        _log.Should().Contain(l => l.StartsWith("[Warning] STRM name collision for series", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task EpisodesWithDistinctNumbers_BothWriteAndNothingCollides()
+    {
+        var result = await RunSeriesSyncAsync(
+            new Episode { EpisodeId = 11, EpisodeNum = 1, Season = 1, Title = "First", ContainerExtension = "mkv" },
+            new Episode { EpisodeId = 22, EpisodeNum = 2, Season = 1, Title = "Second", ContainerExtension = "mkv" })
+            .ConfigureAwait(true);
+
+        result.EpisodeNameCollisions.Should().Be(0);
+        result.EpisodesCreated.Should().Be(2);
+        Directory.GetFiles(Path.Combine(_libraryPath, "Series"), "*.strm", SearchOption.AllDirectories)
+            .Should().HaveCount(2);
+    }
+
+    private async Task<SyncResult> RunSeriesSyncAsync(params Episode[] episodes)
+    {
+        _client.Setup(c => c.GetSeriesCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Shows" } });
+        _client.Setup(c => c.GetSeriesByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Series> { new() { SeriesId = 7, Name = "Collide Show (2024)" } });
+        _client.Setup(c => c.GetSeriesStreamsBySeriesAsync(It.IsAny<ConnectionInfo>(), 7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SeriesStreamInfo
+            {
+                Seasons = new List<Season> { new() { SeasonNumber = 1 } },
+                Episodes = new Dictionary<int, ICollection<Episode>> { [1] = new List<Episode>(episodes) },
+            });
+
+        return await RunSyncAsync(syncMovies: false, syncSeries: true, useShippedDefaults: false).ConfigureAwait(true);
+    }
+
+    private Task<SyncResult> RunMovieSyncAsync(params StreamInfo[] streams)
+        => RunMovieSyncAsync(streams, useShippedDefaults: false);
+
+    private async Task<SyncResult> RunMovieSyncAsync(StreamInfo[] streams, bool useShippedDefaults)
+    {
+        _client.Setup(c => c.GetVodCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Movies" } });
+        _client.Setup(c => c.GetVodStreamsByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StreamInfo>(streams));
+
+        return await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults).ConfigureAwait(true);
+    }
+
+    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults)
     {
         var appPaths = new Mock<IServerApplicationPaths>();
         appPaths.Setup(p => p.PluginConfigurationsPath).Returns(_libraryPath);
@@ -158,22 +274,17 @@ public class StrmNameCollisionTests : IDisposable
                 Username = "u",
                 Password = "p",
                 LibraryPath = _libraryPath,
-                SyncMovies = true,
-                SyncSeries = false,
+                SyncMovies = syncMovies,
+                SyncSeries = syncSeries,
                 CleanupOrphans = false,
-                EnableIncrementalSync = false,
-                SmartSkipExisting = false,
+                EnableIncrementalSync = useShippedDefaults,
+                SmartSkipExisting = useShippedDefaults,
                 DownloadArtworkForUnmatched = false,
                 SyncParallelism = 1,
             },
         ];
         plugin.Configuration.EnableLiveTv = false;
         plugin.Configuration.EnableMetadataLookup = false;
-
-        _client.Setup(c => c.GetVodCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Movies" } });
-        _client.Setup(c => c.GetVodStreamsByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<StreamInfo>(streams));
 
         var service = new StrmSyncService(
             _client.Object,

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
@@ -241,21 +241,48 @@ public class StrmNameCollisionTests : IDisposable
         return await RunSyncAsync(syncMovies: false, syncSeries: true, useShippedDefaults: false).ConfigureAwait(true);
     }
 
-    // The claim set deliberately compares Ordinal. syncedFiles uses OrdinalIgnoreCase because
-    // erring towards "already known" protects files from orphan cleanup, but the same comparer
-    // here errs towards refusing a write, and on a case-sensitive filesystem two titles differing
-    // only in case are two legitimately distinct paths. Asserting on the collision count rather
-    // than the file count keeps this meaningful on case-insensitive filesystems too.
+    // Neither comparer is safe on both platforms: case-sensitively "The Matrix" and "THE MATRIX"
+    // are two real paths and folding them refuses a legitimate write, case-insensitively they are
+    // one file and not folding them lets the second silently overwrite the first. The guard follows
+    // the filesystem, so this test asserts what the host actually does rather than one platform's
+    // answer, and fails if the two ever disagree.
     [Fact]
-    public async Task TitlesDifferingOnlyInCase_AreNotTreatedAsACollision()
+    public async Task TitlesDifferingOnlyInCase_FollowTheFilesystem()
     {
+        bool caseSensitive = IsCaseSensitive(_libraryPath);
+
         var result = await RunMovieSyncAsync(
             new StreamInfo { StreamId = 100, Name = "Case Movie (2024)", ContainerExtension = "mp4" },
             new StreamInfo { StreamId = 200, Name = "CASE MOVIE (2024)", ContainerExtension = "mp4" })
             .ConfigureAwait(true);
 
-        result.MovieNameCollisions.Should().Be(0, "case differences are distinct paths, not a collision");
+        var written = Directory.GetFiles(Path.Combine(_libraryPath, "Movies"), "*.strm", SearchOption.AllDirectories);
         result.Errors.Should().Be(0);
+
+        if (caseSensitive)
+        {
+            result.MovieNameCollisions.Should().Be(0, "these are two distinct paths here");
+            written.Should().HaveCount(2);
+        }
+        else
+        {
+            result.MovieNameCollisions.Should().Be(1, "these are one file here, so the second must be refused");
+            written.Should().HaveCount(1);
+        }
+    }
+
+    private static bool IsCaseSensitive(string dir)
+    {
+        var probe = Path.Combine(dir, "CaseProbe.tmp");
+        File.WriteAllText(probe, string.Empty);
+        try
+        {
+            return !File.Exists(Path.Combine(dir, "caseprobe.tmp"));
+        }
+        finally
+        {
+            File.Delete(probe);
+        }
     }
 
     // Providers are allowed to share a LibraryPath: PluginConfiguration records

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
@@ -1,0 +1,199 @@
+// Copyright (C) 2024  Roland Breitschaft
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Client;
+using Jellyfin.Xtream.Library.Client.Models;
+using Jellyfin.Xtream.Library.Service;
+using Jellyfin.Xtream.Library.Tests.Helpers;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+/// <summary>
+/// Two provider streams that share a title and a recognised quality tag produce the same STRM
+/// file name, because the name is built from the folder name and the version label alone. Before
+/// the guard, the second stream silently overwrote the first: the File.Exists branch compares the
+/// file contents against a stream URL that embeds the stream id, so it can never match across two
+/// different streams and always fell through to the overwrite. Nothing was logged and no counter
+/// moved, and with SyncParallelism above 1 the surviving stream flipped between runs (GitHub #74).
+/// </summary>
+[Collection("PluginSingletonTests")]
+public class StrmNameCollisionTests : IDisposable
+{
+    private readonly string _libraryPath;
+    private readonly Mock<IXtreamClient> _client = new();
+    private readonly List<string> _log = [];
+
+    private sealed class ListLogger(List<string> sink) : Microsoft.Extensions.Logging.ILogger<StrmSyncService>
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => sink.Add($"[{logLevel}] {formatter(state, exception)}");
+    }
+
+    public StrmNameCollisionTests()
+    {
+        _libraryPath = Path.Combine(Path.GetTempPath(), "xtream-collision-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_libraryPath);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_libraryPath))
+            {
+                Directory.Delete(_libraryPath, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort; a leftover temp directory must not fail the suite.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task TwoStreamsSharingTitleAndQualityTag_WriteOneFileAndCountTheCollision()
+    {
+        // Both resolve to "Duplicate Movie (2024)" with version label "FHD", so both want
+        // "Duplicate Movie (2024) - FHD.strm".
+        var result = await RunMovieSyncAsync(
+            new StreamInfo { StreamId = 100, Name = "Duplicate Movie (2024) - [FHD]", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "Duplicate Movie (2024) - [FHD]", ContainerExtension = "mp4" })
+            .ConfigureAwait(true);
+
+        var movieFolder = Path.Combine(_libraryPath, "Movies", "Duplicate Movie (2024)");
+        var written = Directory.Exists(movieFolder)
+            ? Directory.GetFiles(movieFolder, "*.strm")
+            : Array.Empty<string>();
+
+        written.Should().HaveCount(1, "the two streams collapse to one name");
+        result.MovieNameCollisions.Should().Be(1, "the refusal has to be counted, not silent");
+        result.MoviesCreated.Should().Be(1);
+        result.Errors.Should().Be(0, "a collision is a provider quirk, not a sync failure");
+
+        // The counter reaches the caller only if it is aggregated into the global result as well
+        // as the per-provider one. That wiring is easy to forget and invisible to a unit test.
+        _log.Should().Contain(l => l.StartsWith("[Warning] STRM name collision for movie", StringComparison.Ordinal));
+
+        // The surviving file belongs to exactly one of the two streams, and was not rewritten
+        // by the other. Before the fix the content was whichever stream happened to finish last.
+        var content = await File.ReadAllTextAsync(written[0]).ConfigureAwait(true);
+        content.Should().Match(c => c.Contains("/100.mp4", StringComparison.Ordinal) || c.Contains("/200.mp4", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TwoStreamsWithDifferentQualityTags_BothWriteAndNothingCollides()
+    {
+        // The regression guard for #74's actual feature: distinct tags still group into one
+        // folder as separate versions, which is what the version dropdown is built on.
+        var result = await RunMovieSyncAsync(
+            new StreamInfo { StreamId = 100, Name = "Variant Movie (2024) - [FHD]", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "Variant Movie (2024) - [4K]", ContainerExtension = "mp4" })
+            .ConfigureAwait(true);
+
+        var movieFolder = Path.Combine(_libraryPath, "Movies", "Variant Movie (2024)");
+        Directory.GetFiles(movieFolder, "*.strm").Should().HaveCount(2);
+        result.MovieNameCollisions.Should().Be(0);
+        result.MoviesCreated.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task TwoStreamsSharingAVersionTag_CollideTheSameWayAsAQualityTag()
+    {
+        // V1/V2 became version labels in #75, so they can collide exactly like FHD does.
+        var result = await RunMovieSyncAsync(
+            new StreamInfo { StreamId = 100, Name = "Tagged Movie (2024) - [V1]", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "Tagged Movie (2024) - [V1]", ContainerExtension = "mp4" })
+            .ConfigureAwait(true);
+
+        result.MovieNameCollisions.Should().Be(1);
+        Directory.GetFiles(Path.Combine(_libraryPath, "Movies", "Tagged Movie (2024)"), "*.strm")
+            .Should().HaveCount(1);
+    }
+
+    private async Task<SyncResult> RunMovieSyncAsync(params StreamInfo[] streams)
+    {
+        var appPaths = new Mock<IServerApplicationPaths>();
+        appPaths.Setup(p => p.PluginConfigurationsPath).Returns(_libraryPath);
+        appPaths.Setup(p => p.DataPath).Returns(_libraryPath);
+        appPaths.Setup(p => p.ProgramDataPath).Returns(_libraryPath);
+        appPaths.Setup(p => p.CachePath).Returns(_libraryPath);
+        appPaths.Setup(p => p.TempDirectory).Returns(_libraryPath);
+        appPaths.Setup(p => p.PluginsPath).Returns(_libraryPath);
+
+        // Constructing the plugin publishes Plugin.Instance, which SyncAsync reads.
+        var plugin = new Plugin(appPaths.Object, new RealXmlSerializer());
+        plugin.Configuration.Providers =
+        [
+            new ProviderConfig
+            {
+                Name = "test",
+                BaseUrl = "http://provider.test",
+                Username = "u",
+                Password = "p",
+                LibraryPath = _libraryPath,
+                SyncMovies = true,
+                SyncSeries = false,
+                CleanupOrphans = false,
+                EnableIncrementalSync = false,
+                SmartSkipExisting = false,
+                DownloadArtworkForUnmatched = false,
+                SyncParallelism = 1,
+            },
+        ];
+        plugin.Configuration.EnableLiveTv = false;
+        plugin.Configuration.EnableMetadataLookup = false;
+
+        _client.Setup(c => c.GetVodCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Movies" } });
+        _client.Setup(c => c.GetVodStreamsByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StreamInfo>(streams));
+
+        var service = new StrmSyncService(
+            _client.Object,
+            new Mock<IDispatcharrClient>().Object,
+            new Mock<ILibraryManager>().Object,
+            new Mock<IMetadataLookupService>().Object,
+            new SnapshotService(appPaths.Object, NullLogger<SnapshotService>.Instance),
+            new DeltaCalculator(NullLogger<DeltaCalculator>.Instance),
+            new LiveTvService(_client.Object, appPaths.Object, MockAppHost(), NullLogger<LiveTvService>.Instance),
+            appPaths.Object,
+            new ListLogger(_log));
+
+        return await service.SyncAsync(CancellationToken.None).ConfigureAwait(true);
+    }
+
+    private static IServerApplicationHost MockAppHost()
+    {
+        var host = new Mock<IServerApplicationHost>();
+        host.Setup(h => h.GetApiUrlForLocalAccess(It.IsAny<System.Net.IPAddress>(), It.IsAny<bool>()))
+            .Returns("http://127.0.0.1:8096");
+        return host.Object;
+    }
+}

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -112,6 +112,15 @@ public partial class StrmSyncService
     }
 
     /// <summary>
+    /// Gets the comparer for STRM paths claimed during a sync run. Linux filesystems are case-sensitive,
+    /// Windows and macOS default to case-insensitive, and the collision guard is only correct when
+    /// it agrees with the filesystem underneath it. Exposed to the tests so they can assert the
+    /// behaviour their host actually produces rather than hard-coding one platform's answer.
+    /// </summary>
+    internal static StringComparer PathClaimComparer =>
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    /// <summary>
     /// Gets the result of the last sync operation.
     /// </summary>
     public SyncResult? LastSyncResult { get; private set; }
@@ -592,11 +601,14 @@ public partial class StrmSyncService
         // STRM paths written during this run, shared across every provider. Providers are allowed
         // to share a LibraryPath (PluginConfiguration only records HasDuplicateLibraryPaths, it
         // does not refuse the config), so a per-provider set would let the second provider
-        // overwrite the first one's file with nothing counted. Ordinal on purpose: syncedFiles is
-        // OrdinalIgnoreCase because that errs towards protecting files from orphan cleanup, but
-        // the same comparer here would err towards refusing writes, and on a case-sensitive
-        // filesystem two titles differing only in case are two legitimately distinct paths.
-        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+        // overwrite the first one's file with nothing counted.
+        //
+        // The comparer has to follow the filesystem, because neither choice is safe on both.
+        // Case-sensitively, "The Matrix" and "THE MATRIX" are two real paths and folding them
+        // would refuse a legitimate write. Case-insensitively they are one file, and not folding
+        // them would hand out two claims and let the second silently overwrite the first, which
+        // is the exact bug this guard exists to stop.
+        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(PathClaimComparer);
 
         // Check if sync is suppressed (e.g., after CleanLibraries)
         if (_syncSuppressed)
@@ -1892,6 +1904,15 @@ public partial class StrmSyncService
                             // File was created by another thread/process, skip
                             continue;
                         }
+                        catch
+                        {
+                            // The claim is only worth holding if this stream actually produced the
+                            // file. Keeping it after a failed create would refuse a later duplicate
+                            // that might have succeeded, and the name would end up with no STRM at
+                            // all. Hand it back and let the original handler count the error.
+                            claimedStrmPaths.TryRemove(strmPath, out _);
+                            throw;
+                        }
 
                         _logger.LogDebug("Created movie STRM: {StrmPath}", strmPath);
                         } // end strmEntries foreach
@@ -2819,6 +2840,14 @@ public partial class StrmSyncService
                                 {
                                     // File was created by another thread/process, skip
                                     continue;
+                                }
+                                catch
+                                {
+                                    // See the movie path: a claim is only worth holding once the
+                                    // file exists, otherwise a later duplicate that could have
+                                    // succeeded is refused and the name gets no STRM at all.
+                                    claimedStrmPaths.TryRemove(strmPath, out _);
+                                    throw;
                                 }
 
                                 // Write episode NFO with media info if enabled (only for first target folder)

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -1145,6 +1145,7 @@ public partial class StrmSyncService
         globalResult.MoviesSkipped += providerResult.MoviesSkipped;
         globalResult.MoviesDeleted += providerResult.MoviesDeleted;
         globalResult.MoviesUnmatched += providerResult.MoviesUnmatched;
+        globalResult.MovieNameCollisions += providerResult.MovieNameCollisions;
         globalResult.SeriesCreated += providerResult.SeriesCreated;
         globalResult.SeriesSkipped += providerResult.SeriesSkipped;
         globalResult.SeriesDeleted += providerResult.SeriesDeleted;
@@ -1155,6 +1156,7 @@ public partial class StrmSyncService
         globalResult.EpisodesUpdated += providerResult.EpisodesUpdated;
         globalResult.EpisodesSkipped += providerResult.EpisodesSkipped;
         globalResult.EpisodesDeleted += providerResult.EpisodesDeleted;
+        globalResult.EpisodeNameCollisions += providerResult.EpisodeNameCollisions;
         globalResult.FilesDeleted += providerResult.FilesDeleted;
         globalResult.SeriesUnmatched += providerResult.SeriesUnmatched;
         globalResult.Errors += providerResult.Errors;
@@ -1315,6 +1317,7 @@ public partial class StrmSyncService
         int moviesCreated = 0;
         int moviesUpdated = 0;
         int moviesSkipped = 0;
+        int nameCollisions = 0;
         int errors = 0;
         int unmatchedCount = 0;
         var failedItems = new ConcurrentBag<FailedItem>();
@@ -1823,7 +1826,23 @@ public partial class StrmSyncService
                         {
                         string strmPath = Path.Combine(movieFolder, strmFileName);
 
-                        syncedFiles.TryAdd(strmPath, 0);
+                        // TryAdd fails when another stream in this run already claimed this exact
+                        // path. The name is built from the folder name and the version label only,
+                        // so two streams sharing a title and a quality tag produce the same one.
+                        // Writing anyway would silently replace the other stream's file: the
+                        // File.Exists branch below compares content against a URL that embeds the
+                        // stream id, so it can never match across two streams and always falls
+                        // through to the overwrite. Refuse instead, and count it.
+                        if (!syncedFiles.TryAdd(strmPath, 0))
+                        {
+                            Interlocked.Increment(ref nameCollisions);
+                            _logger.LogWarning(
+                                "STRM name collision for movie {MovieName}: {Path} was already claimed by another stream in this run; refusing to overwrite it with stream {StreamId}",
+                                baseName,
+                                strmPath,
+                                stream.StreamId);
+                            continue;
+                        }
 
                         if (File.Exists(strmPath))
                         {
@@ -1976,9 +1995,17 @@ public partial class StrmSyncService
         result.MoviesCreated += moviesCreated;
         result.MoviesUpdated += moviesUpdated;
         result.MoviesSkipped += moviesSkipped;
+        result.MovieNameCollisions += nameCollisions;
         result.AddErrors(errors);
         result.AddFailedItems(failedItems);
         result.MoviesUnmatched = unmatchedCount;
+
+        if (nameCollisions > 0)
+        {
+            _logger.LogWarning(
+                "{Count} movie STRM files were not written because a different provider stream had already claimed the same name. The provider is offering duplicate streams that share a title and a quality tag.",
+                nameCollisions);
+        }
 
         // Log unmatched movies
         if (unmatchedCount > 0)
@@ -2066,6 +2093,7 @@ public partial class StrmSyncService
         int episodesCreated = 0;
         int episodesUpdated = 0;
         int episodesSkipped = 0;
+        int episodeNameCollisions = 0;
         int errors = 0;
         int smartSkipped = 0;
         int unmatchedCount = 0;
@@ -2715,7 +2743,22 @@ public partial class StrmSyncService
                                 string episodeFileName = BuildEpisodeFileName(seriesName, seasonNumber, episode, provider.CustomTitleRemoveTerms, provider.RegexRemovalPatterns);
                                 string strmPath = Path.Combine(seasonFolder, episodeFileName);
 
-                                syncedFiles.TryAdd(strmPath, 0);
+                                // Same guard as the movie path: TryAdd fails when another episode
+                                // in this run already claimed this path, which happens when two
+                                // episodes share a series name and a season/episode number. The
+                                // File.Exists branch below cannot tell them apart, because it
+                                // compares against a URL carrying the episode id, so it would
+                                // silently overwrite. Refuse and count instead.
+                                if (!syncedFiles.TryAdd(strmPath, 0))
+                                {
+                                    Interlocked.Increment(ref episodeNameCollisions);
+                                    _logger.LogWarning(
+                                        "STRM name collision for series {SeriesName}: {Path} was already claimed by another episode in this run; refusing to overwrite it with episode {EpisodeId}",
+                                        baseName,
+                                        strmPath,
+                                        episode.EpisodeId);
+                                    continue;
+                                }
 
                                 // Build stream URL
                                 string extension = string.IsNullOrEmpty(episode.ContainerExtension) ? "mkv" : episode.ContainerExtension;
@@ -2893,6 +2936,15 @@ public partial class StrmSyncService
         result.EpisodesCreated += episodesCreated;
         result.EpisodesUpdated += episodesUpdated;
         result.EpisodesSkipped += episodesSkipped;
+        result.EpisodeNameCollisions += episodeNameCollisions;
+
+        if (episodeNameCollisions > 0)
+        {
+            _logger.LogWarning(
+                "{Count} episode STRM files were not written because a different episode had already claimed the same name. The provider is offering episodes that share a series name and a season/episode number.",
+                episodeNameCollisions);
+        }
+
         result.AddErrors(errors);
         result.AddFailedItems(failedItems);
         result.SeriesUnmatched = unmatchedCount;
@@ -3985,6 +4037,15 @@ public class SyncResult
     public int MoviesDeleted { get; set; }
 
     /// <summary>
+    /// Gets or sets the number of movie STRM files that were not written because another
+    /// provider stream in the same run had already claimed the identical path. Two streams
+    /// collapse to one path when they share a title and a recognised quality tag, since the
+    /// file name is built from those two alone. Non-zero means the provider is offering
+    /// duplicate streams the plugin cannot tell apart by name.
+    /// </summary>
+    public int MovieNameCollisions { get; set; }
+
+    /// <summary>
     /// Gets the total number of movies (created + skipped + updated).
     /// </summary>
     public int TotalMovies => MoviesCreated + MoviesSkipped + MoviesUpdated;
@@ -4048,6 +4109,14 @@ public class SyncResult
     /// Gets or sets the number of episodes deleted (orphans).
     /// </summary>
     public int EpisodesDeleted { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of episode STRM files that were not written because another
+    /// episode in the same run had already claimed the identical path. See
+    /// <see cref="MovieNameCollisions"/>; episode names are built from the series name plus
+    /// the season and episode numbers, so two episodes sharing those collide the same way.
+    /// </summary>
+    public int EpisodeNameCollisions { get; set; }
 
     /// <summary>
     /// Gets the total number of episodes (created + skipped + updated).

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -1319,6 +1319,11 @@ public partial class StrmSyncService
         int moviesSkipped = 0;
         int nameCollisions = 0;
         int errors = 0;
+
+        // Paths claimed by a write in this run. Deliberately separate from syncedFiles, which
+        // also collects existing files purely so orphan cleanup leaves them alone; a path in
+        // there means "exists, do not delete", not "another stream wrote this".
+        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         int unmatchedCount = 0;
         var failedItems = new ConcurrentBag<FailedItem>();
         var unmatchedMovies = new ConcurrentBag<string>();
@@ -1826,14 +1831,16 @@ public partial class StrmSyncService
                         {
                         string strmPath = Path.Combine(movieFolder, strmFileName);
 
-                        // TryAdd fails when another stream in this run already claimed this exact
+                        syncedFiles.TryAdd(strmPath, 0);
+
+                        // TryAdd fails when another stream in this run already wrote this exact
                         // path. The name is built from the folder name and the version label only,
                         // so two streams sharing a title and a quality tag produce the same one.
                         // Writing anyway would silently replace the other stream's file: the
                         // File.Exists branch below compares content against a URL that embeds the
                         // stream id, so it can never match across two streams and always falls
                         // through to the overwrite. Refuse instead, and count it.
-                        if (!syncedFiles.TryAdd(strmPath, 0))
+                        if (!claimedStrmPaths.TryAdd(strmPath, 0))
                         {
                             Interlocked.Increment(ref nameCollisions);
                             _logger.LogWarning(
@@ -2094,6 +2101,12 @@ public partial class StrmSyncService
         int episodesUpdated = 0;
         int episodesSkipped = 0;
         int episodeNameCollisions = 0;
+
+        // See the note in SyncMoviesAsync: syncedFiles doubles as the orphan-protection set, and
+        // the smart-skip path above adds a fully-populated target folder's existing episodes to it
+        // before a second target folder can force the sync to run. Reusing it as the collision
+        // detector would then refuse legitimate writes, including URL refreshes.
+        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         int errors = 0;
         int smartSkipped = 0;
         int unmatchedCount = 0;
@@ -2743,13 +2756,15 @@ public partial class StrmSyncService
                                 string episodeFileName = BuildEpisodeFileName(seriesName, seasonNumber, episode, provider.CustomTitleRemoveTerms, provider.RegexRemovalPatterns);
                                 string strmPath = Path.Combine(seasonFolder, episodeFileName);
 
+                                syncedFiles.TryAdd(strmPath, 0);
+
                                 // Same guard as the movie path: TryAdd fails when another episode
-                                // in this run already claimed this path, which happens when two
+                                // in this run already wrote this path, which happens when two
                                 // episodes share a series name and a season/episode number. The
                                 // File.Exists branch below cannot tell them apart, because it
                                 // compares against a URL carrying the episode id, so it would
                                 // silently overwrite. Refuse and count instead.
-                                if (!syncedFiles.TryAdd(strmPath, 0))
+                                if (!claimedStrmPaths.TryAdd(strmPath, 0))
                                 {
                                     Interlocked.Increment(ref episodeNameCollisions);
                                     _logger.LogWarning(

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -589,6 +589,15 @@ public partial class StrmSyncService
         config.Validate();
         var globalResult = new SyncResult { StartTime = DateTime.UtcNow };
 
+        // STRM paths written during this run, shared across every provider. Providers are allowed
+        // to share a LibraryPath (PluginConfiguration only records HasDuplicateLibraryPaths, it
+        // does not refuse the config), so a per-provider set would let the second provider
+        // overwrite the first one's file with nothing counted. Ordinal on purpose: syncedFiles is
+        // OrdinalIgnoreCase because that errs towards protecting files from orphan cleanup, but
+        // the same comparer here would err towards refusing writes, and on a case-sensitive
+        // filesystem two titles differing only in case are two legitimately distinct paths.
+        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+
         // Check if sync is suppressed (e.g., after CleanLibraries)
         if (_syncSuppressed)
         {
@@ -661,7 +670,7 @@ public partial class StrmSyncService
                     CurrentProgress.Phase = $"Provider {i + 1}/{enabledProviders.Count}: {provider.Name}";
                 }
 
-                var providerResult = await SyncProviderAsync(providerIndex, provider, linkedToken).ConfigureAwait(false);
+                var providerResult = await SyncProviderAsync(providerIndex, provider, claimedStrmPaths, linkedToken).ConfigureAwait(false);
                 MergeResult(globalResult, providerResult);
             }
 
@@ -819,12 +828,14 @@ public partial class StrmSyncService
     /// </summary>
     /// <param name="providerIndex">Zero-based index of this provider in the Providers list.</param>
     /// <param name="provider">The provider configuration.</param>
+    /// <param name="claimedStrmPaths">STRM paths already written during this sync run, shared across providers.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The sync result for this provider.</returns>
 #pragma warning disable CA5351
     private async Task<SyncResult> SyncProviderAsync(
         int providerIndex,
         ProviderConfig provider,
+        ConcurrentDictionary<string, byte> claimedStrmPaths,
         CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTime.UtcNow };
@@ -943,6 +954,7 @@ public partial class StrmSyncService
                             provider,
                             moviesPath,
                             syncedFiles,
+                            claimedStrmPaths,
                             result,
                             previousSnapshot,
                             allCollectedMovies,
@@ -960,6 +972,7 @@ public partial class StrmSyncService
                         await SyncSeriesAsync(
                             provider,
                             seriesPath,
+                            claimedStrmPaths,
                             syncedFiles,
                             result,
                             previousSnapshot,
@@ -983,6 +996,7 @@ public partial class StrmSyncService
                     provider,
                     moviesPath,
                     syncedFiles,
+                    claimedStrmPaths,
                     result,
                     previousSnapshot,
                     allCollectedMovies,
@@ -995,6 +1009,7 @@ public partial class StrmSyncService
                 await SyncSeriesAsync(
                     provider,
                     seriesPath,
+                    claimedStrmPaths,
                     syncedFiles,
                     result,
                     previousSnapshot,
@@ -1254,6 +1269,7 @@ public partial class StrmSyncService
         ProviderConfig provider,
         string moviesPath,
         ConcurrentDictionary<string, byte> syncedFiles,
+        ConcurrentDictionary<string, byte> claimedStrmPaths,
         SyncResult result,
         ContentSnapshot? previousSnapshot,
         ConcurrentBag<StreamInfo> allCollectedMovies,
@@ -1319,11 +1335,6 @@ public partial class StrmSyncService
         int moviesSkipped = 0;
         int nameCollisions = 0;
         int errors = 0;
-
-        // Paths claimed by a write in this run. Deliberately separate from syncedFiles, which
-        // also collects existing files purely so orphan cleanup leaves them alone; a path in
-        // there means "exists, do not delete", not "another stream wrote this".
-        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         int unmatchedCount = 0;
         var failedItems = new ConcurrentBag<FailedItem>();
         var unmatchedMovies = new ConcurrentBag<string>();
@@ -2030,6 +2041,7 @@ public partial class StrmSyncService
     private async Task SyncSeriesAsync(
         ProviderConfig provider,
         string seriesPath,
+        ConcurrentDictionary<string, byte> claimedStrmPaths,
         ConcurrentDictionary<string, byte> syncedFiles,
         SyncResult result,
         ContentSnapshot? previousSnapshot,
@@ -2101,12 +2113,6 @@ public partial class StrmSyncService
         int episodesUpdated = 0;
         int episodesSkipped = 0;
         int episodeNameCollisions = 0;
-
-        // See the note in SyncMoviesAsync: syncedFiles doubles as the orphan-protection set, and
-        // the smart-skip path above adds a fully-populated target folder's existing episodes to it
-        // before a second target folder can force the sync to run. Reusing it as the collision
-        // detector would then refuse legitimate writes, including URL refreshes.
-        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         int errors = 0;
         int smartSkipped = 0;
         int unmatchedCount = 0;
@@ -2767,6 +2773,11 @@ public partial class StrmSyncService
                                 if (!claimedStrmPaths.TryAdd(strmPath, 0))
                                 {
                                     Interlocked.Increment(ref episodeNameCollisions);
+
+                                    // Counts as skipped, matching the movie path where a refused
+                                    // write leaves allSkipped true. The collision counter says why;
+                                    // without this an episode would land in no total at all.
+                                    Interlocked.Increment(ref episodesSkipped);
                                     _logger.LogWarning(
                                         "STRM name collision for series {SeriesName}: {Path} was already claimed by another episode in this run; refusing to overwrite it with episode {EpisodeId}",
                                         baseName,


### PR DESCRIPTION
Part B of #74. Part A, the V1/V2/V3 pattern, shipped in #75.

## The bug

Two provider streams that share a title and a recognised quality tag produce the same STRM file name, because the name is built from the folder name and the version label alone. The second stream then found the file already present, compared its contents against a stream URL that embeds the stream id, could never match across two different streams, and fell through to the overwrite.

Nothing was logged and no counter moved. With `SyncParallelism` above 1 the surviving stream flipped between runs, so which of the two a user could actually play changed without anything changing on the provider.

Episodes have the identical shape: the name is the series name plus the season and episode number, so two episodes sharing those collide the same way. Providers routinely send no episode title at all, which collapses both to `<series> - S01E01.strm`.

## The fix

The detector already existed and was being thrown away. `TryAdd` returns false when a path has already been claimed, and the bool was discarded on both write paths. Use it, refuse the write, log a warning naming the path and the losing stream id, and count it in `SyncResult` as `MovieNameCollisions` / `EpisodeNameCollisions`.

First writer wins. Which of the two survives is still decided by processing order; see below.

## One thing worth flagging in review

The first cut used `syncedFiles` itself as the detector, and that was wrong in a way that matters. That dictionary carries two meanings: paths written this run, and paths that merely exist and must survive orphan cleanup. The incremental and smart-skip paths bulk-add the second kind, and both default to on.

The series path is where it bites. The smart-skip check walks target folders, adds a fully-populated folder's existing episodes to `syncedFiles`, and only then can a later folder set `anyNeedsSync` and fall through to the real sync. Those paths are in the dictionary by then, so the guard refused writes for a folder in conflict with nothing. A provider that changed its URLs would have found the refresh blocked by the guard added to prevent data loss.

Second commit tracks written paths in their own per-method dictionary. `syncedFiles` keeps doing what it did.

## Tests

The tests drive a real sync through `SyncAsync` against a mocked `IXtreamClient` rather than poking the guard directly. That caught two things code reading did not:

- the counters were written to the per-provider `SyncResult` but not aggregated into the `globalResult` that `SyncAsync` returns, so the guard fired, the warning was logged, and the caller still saw zero
- the false positive above, which was hidden by the first tests turning incremental sync and smart skip off

They now run the shipped defaults, including a second sync over the same catalogue and a changed provider URL that still has to be rewritten.

604 tests green.

## Deferred, not forgotten

- Making the file name itself deterministic, by suffixing the stream id, would remove the order dependence. It renames files for anyone who already has duplicates, so it is a migration and wants its own change.
- A movie collision increments both `MovieNameCollisions` and `MoviesSkipped`, one event in two counters. Harmless now, but it will read as a discrepancy once the last-sync panel from #77 shows both. A collided episode lands in no episode counter at all.

Closes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate movie or episode STRM files from overwriting one another during synchronization.
  * Conflicting files are now skipped safely, with collision totals reported separately for movies and episodes.
  * Improved synchronization logging and result reporting for filename collisions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->