### PR TITLE
Live TV: exclude-categories mode

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Client/LiveStreamInfoTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Client/LiveStreamInfoTests.cs
@@ -66,4 +66,91 @@ public class LiveStreamInfoTests
 
         info!.Added.Should().BeEmpty();
     }
+
+    // GitHub #79 added CategoryIds for exclude-mode filtering. It is deserialized on the shared
+    // fetch path, so a shape that throws takes down every Live TV mode - including the two that
+    // never read the field. Same hazard as `added` above, so the same tolerance is required.
+
+    [Fact]
+    public void Deserialize_CategoryIdsAsIntArray_Succeeds()
+    {
+        var json = "{\"category_ids\": [10, 20]}";
+
+        var info = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        info!.CategoryIds.Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void Deserialize_CategoryIdsAsStringArray_Succeeds()
+    {
+        var json = "{\"category_ids\": [\"10\", \"20\"]}";
+
+        var info = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        info!.CategoryIds.Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void Deserialize_CategoryIdsAsBareScalar_Succeeds()
+    {
+        // A provider reporting one category may send it unwrapped rather than as a 1-element array.
+        var json = "{\"category_ids\": 10}";
+
+        var info = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        info!.CategoryIds.Should().BeEquivalentTo(new[] { 10 });
+    }
+
+    [Fact]
+    public void Deserialize_CategoryIdsAsCommaSeparatedString_Succeeds()
+    {
+        var json = "{\"category_ids\": \"10,20\"}";
+
+        var info = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        info!.CategoryIds.Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void Deserialize_CategoryIdsNullOrMissingOrEmpty_DoesNotThrow()
+    {
+        JsonConvert.DeserializeObject<LiveStreamInfo>("{\"category_ids\": null}")!
+            .CategoryIds.Should().BeNull();
+
+        JsonConvert.DeserializeObject<LiveStreamInfo>("{}")!
+            .CategoryIds.Should().BeNull();
+
+        JsonConvert.DeserializeObject<LiveStreamInfo>("{\"category_ids\": []}")!
+            .CategoryIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_CategoryIdsGarbage_DegradesInsteadOfThrowing()
+    {
+        // Whatever a provider invents here, losing the secondary membership of one channel is
+        // survivable; failing the fetch is not.
+        JsonConvert.DeserializeObject<LiveStreamInfo>("{\"category_ids\": \"\"}")!
+            .CategoryIds.Should().BeEmpty();
+
+        JsonConvert.DeserializeObject<LiveStreamInfo>("{\"category_ids\": {\"a\": 1}}")!
+            .CategoryIds.Should().BeNull();
+
+        JsonConvert.DeserializeObject<LiveStreamInfo>("{\"category_ids\": [\"x\", 10]}")!
+            .CategoryIds.Should().BeEquivalentTo(new[] { 10 });
+    }
+
+    [Fact]
+    public void Deserialize_FullChannelWithAwkwardCategoryIds_KeepsOtherFields()
+    {
+        // The point of the tolerance: one odd field must not cost the rest of the channel.
+        var json = "{\"stream_id\": 7, \"name\": \"BBC One\", \"category_id\": \"10\", \"category_ids\": 10}";
+
+        var info = JsonConvert.DeserializeObject<LiveStreamInfo>(json);
+
+        info!.StreamId.Should().Be(7);
+        info.Name.Should().Be("BBC One");
+        info.CategoryId.Should().Be(10);
+        info.CategoryIds.Should().BeEquivalentTo(new[] { 10 });
+    }
 }

--- a/Jellyfin.Xtream.Library.Tests/PluginConfigurationTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/PluginConfigurationTests.cs
@@ -348,6 +348,47 @@ public class PluginConfigurationTests
     }
 
     [Fact]
+    public void LiveChannelMode_ExcludeSelectedRoundTripsThroughXmlSerialization()
+    {
+        var original = new PluginConfiguration
+        {
+            LiveChannelMode = LiveChannelSelectionMode.ExcludeSelected,
+            SelectedLiveCategoryIds = new[] { 10, 20 },
+        };
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, original);
+        using var reader = new StringReader(writer.ToString());
+        var roundtripped = (PluginConfiguration)serializer.Deserialize(reader)!;
+
+        roundtripped.LiveChannelMode.Should().Be(LiveChannelSelectionMode.ExcludeSelected);
+        roundtripped.SelectedLiveCategoryIds.Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void LiveChannelSelectionMode_NumericValuesAreStable()
+    {
+        // GitHub #79 appended ExcludeSelected rather than slotting it next to Custom. Inserting a
+        // member above Custom would renumber it, and a config not round-tripped by name would then
+        // read every existing Custom setup as ExcludeSelected - inverting the user's channel list
+        // rather than failing. Pin the numbering so that stays a deliberate choice.
+        ((int)LiveChannelSelectionMode.IncludeAll).Should().Be(0);
+        ((int)LiveChannelSelectionMode.Custom).Should().Be(1);
+        ((int)LiveChannelSelectionMode.ExcludeSelected).Should().Be(2);
+    }
+
+    [Fact]
+    public void ShouldMigrateToCustomMode_ExcludeSelectedMode_DoesNotMigrate()
+    {
+        // The upgrade migration only promotes IncludeAll configs that predate the mode flag.
+        // A user who deliberately chose ExcludeSelected must never be flipped to Custom, which
+        // would turn their exclusion list into an inclusion list.
+        PluginConfiguration.ShouldMigrateToCustomMode(LiveChannelSelectionMode.ExcludeSelected, 5, 0).Should().BeFalse();
+        PluginConfiguration.ShouldMigrateToCustomMode(LiveChannelSelectionMode.ExcludeSelected, 0, 3).Should().BeFalse();
+    }
+
+    [Fact]
     public void UseBetaChannel_DefaultsToFalse()
     {
         var config = new PluginConfiguration();

--- a/Jellyfin.Xtream.Library.Tests/Service/LiveTvServiceTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/LiveTvServiceTests.cs
@@ -157,6 +157,126 @@ public class LiveTvServiceTests
             .Should().Be(LiveTvService.CategoryFetchStrategy.BySelectedCategories);
     }
 
+    // GitHub #79: ExcludeSelected reads SelectedLiveCategoryIds as an exclusion list, so that
+    // categories the provider adds later are synced without anyone having to retick the list.
+
+    [Fact]
+    public void ChooseCategoryFetchStrategy_ExcludeSelectedMode_AlwaysAllFromProvider()
+    {
+        // The trap this pins: falling through to the Custom branch would fetch *by*
+        // SelectedLiveCategoryIds, i.e. exactly the categories the user asked to be rid of.
+        // Nothing would throw - the channel list would just be inverted.
+        LiveTvService.ChooseCategoryFetchStrategy(LiveChannelSelectionMode.ExcludeSelected, selectedCategoryCount: 3)
+            .Should().Be(LiveTvService.CategoryFetchStrategy.AllFromProvider);
+
+        LiveTvService.ChooseCategoryFetchStrategy(LiveChannelSelectionMode.ExcludeSelected, selectedCategoryCount: 0)
+            .Should().Be(LiveTvService.CategoryFetchStrategy.AllFromProvider);
+    }
+
+    [Fact]
+    public void FilterExcludedCategories_EmptySelection_KeepsEverything()
+    {
+        // Excluding nothing excludes nothing. Deliberately the opposite of Custom mode's
+        // empty-means-none rule, and matching what Movies and Series do (GitHub #76).
+        // Do not "fix" this into None by analogy with Custom.
+        var channels = MakeCategorisedChannels((1, 10), (2, 20));
+
+        LiveTvService.FilterExcludedCategories(channels, Array.Empty<int>()).Should().HaveCount(2);
+        LiveTvService.FilterExcludedCategories(channels, null).Should().BeSameAs(channels);
+    }
+
+    [Fact]
+    public void FilterExcludedCategories_DropsChannelsInExcludedCategories()
+    {
+        var channels = MakeCategorisedChannels((1, 10), (2, 20), (3, 10), (4, 30));
+
+        var result = LiveTvService.FilterExcludedCategories(channels, new[] { 10 });
+
+        result.Select(c => c.StreamId).Should().BeEquivalentTo(new[] { 2, 4 });
+    }
+
+    [Fact]
+    public void FilterExcludedCategories_ChannelWithoutCategory_IsKept()
+    {
+        // No category means it cannot be in the exclusion list.
+        var channels = new List<LiveStreamInfo>
+        {
+            new() { StreamId = 1, Name = "Uncategorised", Num = 1, CategoryId = null },
+            new() { StreamId = 2, Name = "Excluded", Num = 2, CategoryId = 10 },
+        };
+
+        var result = LiveTvService.FilterExcludedCategories(channels, new[] { 10 });
+
+        result.Select(c => c.StreamId).Should().BeEquivalentTo(new[] { 1 });
+    }
+
+    [Fact]
+    public void FilterExcludedCategories_HonoursSecondaryCategoryMembership()
+    {
+        // Some providers put one channel in several categories and report the extras only in
+        // category_ids. Include mode fetches per category, so it picks a channel up through any
+        // of them; excluding on the same union is what keeps Exclude the exact complement.
+        var channels = new List<LiveStreamInfo>
+        {
+            new() { StreamId = 1, Name = "Primary elsewhere", Num = 1, CategoryId = 20, CategoryIds = new[] { 20, 10 } },
+            new() { StreamId = 2, Name = "Untouched", Num = 2, CategoryId = 20, CategoryIds = new[] { 20 } },
+        };
+
+        var result = LiveTvService.FilterExcludedCategories(channels, new[] { 10 });
+
+        result.Select(c => c.StreamId).Should().BeEquivalentTo(new[] { 2 });
+    }
+
+    [Fact]
+    public void FilterExcludedCategories_DoesNotMutateInput()
+    {
+        var channels = MakeCategorisedChannels((1, 10), (2, 20));
+
+        LiveTvService.FilterExcludedCategories(channels, new[] { 10 });
+
+        channels.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ApplyRenderTimeFilters_ExcludedCategoriesReappliedOnSnapshotRestore()
+    {
+        // A snapshot taken before a category was excluded still holds its channels: in this mode
+        // the category filter runs after the fetch instead of deciding what to fetch, so the
+        // snapshot path has to re-apply it or keep serving what the user just excluded.
+        var config = MakeM3UConfig();
+        config.LiveChannelMode = LiveChannelSelectionMode.ExcludeSelected;
+        config.SelectedLiveCategoryIds = new[] { 10 };
+        var channels = MakeCategorisedChannels((1, 10), (2, 20));
+
+        var result = LiveTvService.ApplyRenderTimeFilters(channels, config);
+
+        result.Select(c => c.StreamId).Should().BeEquivalentTo(new[] { 2 });
+    }
+
+    [Fact]
+    public void ApplyRenderTimeFilters_PerChannelExclusionsHonouredInExcludeSelectedMode()
+    {
+        var config = MakeM3UConfig();
+        config.LiveChannelMode = LiveChannelSelectionMode.ExcludeSelected;
+        config.SelectedLiveCategoryIds = Array.Empty<int>();
+        config.ExcludedLiveStreamIds = new[] { 2 };
+        var channels = MakeCategorisedChannels((1, 10), (2, 20));
+
+        var result = LiveTvService.ApplyRenderTimeFilters(channels, config);
+
+        result.Select(c => c.StreamId).Should().BeEquivalentTo(new[] { 1 });
+    }
+
+    private static List<LiveStreamInfo> MakeCategorisedChannels(params (int StreamId, int CategoryId)[] channels) =>
+        channels.Select(c => new LiveStreamInfo
+        {
+            StreamId = c.StreamId,
+            Name = "Channel " + c.StreamId,
+            Num = c.StreamId,
+            CategoryId = c.CategoryId,
+            CategoryIds = new[] { c.CategoryId },
+        }).ToList();
+
     // BUG-008: multi-provider configs (Providers[0] populated, legacy fields empty) used to
     // produce m3u stream URLs shaped like "/live///{streamId}.ts" because BuildStreamUrl
     // read the legacy single-provider fields directly. These tests pin the resolver and the

--- a/Jellyfin.Xtream.Library/Client/FlexibleIntArrayConverter.cs
+++ b/Jellyfin.Xtream.Library/Client/FlexibleIntArrayConverter.cs
@@ -1,0 +1,157 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Xtream.Library.Client;
+
+/// <summary>
+/// Reads an int array from whichever shape a provider actually sends: a JSON array of numbers or
+/// of numeric strings, a bare scalar, or a comma-separated string.
+/// <para>
+/// Xtream providers are inconsistent about collection fields in the same way they are about
+/// <c>added</c> (see <see cref="Models.LiveStreamInfo.Added"/> and GitHub #41). A plain
+/// <c>int[]</c> throws on any shape but the array form, and because these models are deserialized
+/// on the shared fetch path, one such channel fails the entire request - taking down Live TV modes
+/// that never read the field. Anything unrecognisable degrades to null or is skipped instead:
+/// losing one channel's secondary category membership is survivable, failing the fetch is not.
+/// </para>
+/// </summary>
+public class FlexibleIntArrayConverter : JsonConverter
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type objectType) => objectType == typeof(int[]);
+
+    /// <inheritdoc />
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        switch (reader.TokenType)
+        {
+            case JsonToken.Null:
+            case JsonToken.Undefined:
+                return null;
+
+            case JsonToken.StartArray:
+                return ReadArray(reader);
+
+            case JsonToken.Integer:
+                return TryReadScalar(reader, out var single) ? new[] { single } : Array.Empty<int>();
+
+            case JsonToken.String:
+                return ParseDelimited(reader.Value as string);
+
+            default:
+                // An object, a bool, anything else: consume it whole so the reader stays aligned
+                // on the next property, and report "no membership known".
+                reader.Skip();
+                return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (value is not int[] values)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        writer.WriteStartArray();
+        foreach (var item in values)
+        {
+            writer.WriteValue(item);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static int[] ReadArray(JsonReader reader)
+    {
+        var values = new List<int>();
+
+        while (reader.Read() && reader.TokenType != JsonToken.EndArray)
+        {
+            if (TryReadScalar(reader, out var parsed))
+            {
+                values.Add(parsed);
+                continue;
+            }
+
+            // A nested array or object would otherwise leave the reader inside it.
+            if (reader.TokenType is JsonToken.StartArray or JsonToken.StartObject)
+            {
+                reader.Skip();
+            }
+        }
+
+        return values.ToArray();
+    }
+
+    private static int[] ParseDelimited(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return Array.Empty<int>();
+        }
+
+        var values = new List<int>();
+        foreach (var part in raw.Split(','))
+        {
+            if (int.TryParse(part.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                values.Add(parsed);
+            }
+        }
+
+        return values.ToArray();
+    }
+
+    private static bool TryReadScalar(JsonReader reader, out int value)
+    {
+        value = 0;
+
+        switch (reader.TokenType)
+        {
+            case JsonToken.Integer:
+                // Via long: a provider sending something wider than int must not throw here.
+                var wide = Convert.ToInt64(reader.Value, CultureInfo.InvariantCulture);
+                if (wide is < int.MinValue or > int.MaxValue)
+                {
+                    return false;
+                }
+
+                value = (int)wide;
+                return true;
+
+            case JsonToken.String:
+                return int.TryParse(
+                    reader.Value as string,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out value);
+
+            default:
+                return false;
+        }
+    }
+}

--- a/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
+++ b/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
@@ -55,7 +55,10 @@ public class LiveStreamInfo
     // array, and providers that let a channel sit in several categories only show the extras
     // here. Include mode never needed it (it fetches per category, so the provider resolves
     // membership server-side); exclude mode filters client-side and does. See GitHub #79.
+    // Converted leniently: this is deserialized on the shared fetch path, so a provider sending
+    // an unexpected shape here would otherwise fail Live TV entirely. Same reasoning as `added`.
     [JsonProperty("category_ids")]
+    [JsonConverter(typeof(FlexibleIntArrayConverter))]
     public int[]? CategoryIds { get; set; }
 
     [JsonProperty("custom_sid")]

--- a/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
+++ b/Jellyfin.Xtream.Library/Client/Models/LiveStreamInfo.cs
@@ -51,6 +51,13 @@ public class LiveStreamInfo
     [JsonProperty("category_id")]
     public int? CategoryId { get; set; }
 
+    // The primary category above is a scalar, but the API also reports full membership as an
+    // array, and providers that let a channel sit in several categories only show the extras
+    // here. Include mode never needed it (it fetches per category, so the provider resolves
+    // membership server-side); exclude mode filters client-side and does. See GitHub #79.
+    [JsonProperty("category_ids")]
+    public int[]? CategoryIds { get; set; }
+
     [JsonProperty("custom_sid")]
     public string CustomSid { get; set; } = string.Empty;
 

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -995,11 +995,17 @@
                                     <input type="radio" is="emby-radio" name="LiveChannelMode" value="IncludeAll" />
                                     <span>Sync ALL channels from provider</span>
                                 </label>
-                                <label class="emby-radio-label" style="display: block;">
+                                <label class="emby-radio-label" style="display: block; margin-bottom: 4px;">
                                     <input type="radio" is="emby-radio" name="LiveChannelMode" value="Custom" />
                                     <span>Pick specific channels (custom selection)</span>
                                 </label>
+                                <label class="emby-radio-label" style="display: block;">
+                                    <input type="radio" is="emby-radio" name="LiveChannelMode" value="ExcludeSelected" />
+                                    <span>Sync all channels EXCEPT the categories you tick</span>
+                                </label>
                             </div>
+
+                            <div class="fieldDescription" id="liveChannelModeHint" style="margin-bottom: 10px;"></div>
 
                             <div id="liveCustomSection" style="display: none;">
                                 <div>

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -1020,10 +1020,10 @@
                                         <div id="liveCategoryCounter" style="margin-bottom: 8px; font-weight: 500;">0 of 0 categories selected</div>
                                         <div class="category-actions" style="margin-bottom: 8px;">
                                             <button is="emby-button" type="button" class="raised" onclick="XtreamLibraryConfig.selectAllCategories('live')">
-                                                <span>Select all</span>
+                                                <span id="btnLiveSelectAllLabel">Select all</span>
                                             </button>
                                             <button is="emby-button" type="button" class="raised" onclick="XtreamLibraryConfig.deselectAllCategories('live')">
-                                                <span>Deselect all</span>
+                                                <span id="btnLiveDeselectAllLabel">Deselect all</span>
                                             </button>
                                             <button is="emby-button" type="button" class="raised" onclick="XtreamLibraryConfig.clearChannelExclusions()">
                                                 <span>Clear channel exclusions</span>

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -1700,7 +1700,11 @@ const XtreamLibraryConfig = {
             // Master "Select all" implies a clean slate: drop any per-channel exclusions so
             // the user gets every channel from every category. Existing expanded panels
             // need redrawing so the channel checkboxes follow the new state.
-            self.excludedLiveStreamIds = [];
+            //
+            // That reasoning is inverted in ExcludeSelected mode, where ticking everything means
+            // excluding every category. Per-channel exclusions there are not stale leftovers of a
+            // superseded selection, so wiping them would just destroy the user's list.
+            self.clearLiveChannelExclusionsIfMeaningless();
             self.redrawExpandedLiveChannelPanels();
             self.updateLiveCategoryCounter();
         } else if (type === 'vod' || type === 'series') {
@@ -1720,7 +1724,11 @@ const XtreamLibraryConfig = {
             // Same clean-slate logic as Select all — the per-channel exclusion list is
             // meaningless when no category is selected, and leaving stale state behind was
             // the root of the "Deselect All seems broken" report.
-            self.excludedLiveStreamIds = [];
+            //
+            // Also inverted in ExcludeSelected mode: unticking everything there means excluding no
+            // category, i.e. syncing the lot, and per-channel exclusions are the only filter the
+            // user has left. Clearing them would silently undo that.
+            self.clearLiveChannelExclusionsIfMeaningless();
             self.redrawExpandedLiveChannelPanels();
             self.updateLiveCategoryCounter();
         } else if (type === 'vod' || type === 'series') {
@@ -1769,6 +1777,19 @@ const XtreamLibraryConfig = {
         return checked ? checked.value : 'IncludeAll';
     },
 
+    /**
+     * Drops the per-channel exclusion list, but only where a bulk category toggle has genuinely
+     * made it meaningless - which is Custom mode, where the exclusions only ever qualified a
+     * category selection that has just been replaced wholesale. In ExcludeSelected mode they are
+     * an independent filter and must survive.
+     */
+    clearLiveChannelExclusionsIfMeaningless: function () {
+        const self = this;
+        if (self.getLiveChannelMode() !== 'ExcludeSelected') {
+            self.excludedLiveStreamIds = [];
+        }
+    },
+
     updateLiveCategoryCounter: function () {
         const counter = document.getElementById('liveCategoryCounter');
         if (!counter) return;
@@ -1800,6 +1821,15 @@ const XtreamLibraryConfig = {
             } else {
                 hint.textContent = '';
             }
+        }
+
+        // A ticked box excludes rather than includes in the new mode, so "Select all" would read as
+        // a way to get everything while actually syncing nothing.
+        const selectAllLabel = document.getElementById('btnLiveSelectAllLabel');
+        const deselectAllLabel = document.getElementById('btnLiveDeselectAllLabel');
+        if (selectAllLabel && deselectAllLabel) {
+            selectAllLabel.textContent = (mode === 'ExcludeSelected') ? 'Exclude all' : 'Select all';
+            deselectAllLabel.textContent = (mode === 'ExcludeSelected') ? 'Exclude none' : 'Deselect all';
         }
 
         XtreamLibraryConfig.updateLiveCategoryCounter();
@@ -2628,6 +2658,16 @@ function initXtreamLibraryConfig() {
     for (var i = 0; i < liveModeRadios.length; i++) {
         liveModeRadios[i].addEventListener('change', function () {
             XtreamLibraryConfig.updateLiveChannelModeVisibility();
+
+            // The auto-load on page open reads the *saved* mode, so switching into a mode that
+            // needs the category list would otherwise reveal an empty panel until the user found
+            // the Load Categories button.
+            var mode = XtreamLibraryConfig.getLiveChannelMode();
+            var needsList = (mode === 'Custom' || mode === 'ExcludeSelected');
+            var alreadyLoaded = document.querySelectorAll('input[data-category-type="live"]').length > 0;
+            if (needsList && !alreadyLoaded) {
+                XtreamLibraryConfig.loadLiveCategories();
+            }
         });
     }
 

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -327,8 +327,8 @@ const XtreamLibraryConfig = {
             self.selectedLiveCategoryIds = config.SelectedLiveCategoryIds || [];
             self.excludedLiveStreamIds = config.ExcludedLiveStreamIds || [];
 
-            // Live channel selection mode (IncludeAll | Custom). Backend defaults to IncludeAll on
-            // fresh installs; existing configs with state are migrated to Custom on startup.
+            // Live channel selection mode (IncludeAll | Custom | ExcludeSelected). Backend defaults to
+            // IncludeAll on fresh installs; existing configs with state are migrated to Custom on startup.
             var liveMode = config.LiveChannelMode || 'IncludeAll';
             var modeRadios = document.getElementsByName('LiveChannelMode');
             for (var i = 0; i < modeRadios.length; i++) {
@@ -352,9 +352,11 @@ const XtreamLibraryConfig = {
 
             Dashboard.hideLoadingMsg();
 
-            // Live categories auto-load (uses provider 0 credentials). Only meaningful in Custom mode.
+            // Live categories auto-load (uses provider 0 credentials). Meaningful in both modes that
+            // read the category list - and required in them, because saveConfig reads the selection
+            // back off these checkboxes. See getLiveCategoryIdsForSave.
             var p0 = self.providers[0];
-            if (p0 && p0.BaseUrl && p0.Username && liveMode === 'Custom') {
+            if (p0 && p0.BaseUrl && p0.Username && (liveMode === 'Custom' || liveMode === 'ExcludeSelected')) {
                 self.loadLiveCategories();
             }
         });
@@ -412,7 +414,7 @@ const XtreamLibraryConfig = {
             config.EpgCacheMinutes = parseInt(document.getElementById('txtEpgCacheMinutes').value) || 30;
             config.EpgDaysToFetch = parseInt(document.getElementById('txtEpgDaysToFetch').value) || 2;
             config.EpgParallelism = parseInt(document.getElementById('txtEpgParallelism').value) || 5;
-            config.SelectedLiveCategoryIds = self.getSelectedCategoryIds('live');
+            config.SelectedLiveCategoryIds = self.getLiveCategoryIdsForSave();
             config.ExcludedLiveStreamIds = self.excludedLiveStreamIds.slice();
 
             var checkedMode = document.querySelector('input[name="LiveChannelMode"]:checked');
@@ -1665,6 +1667,20 @@ const XtreamLibraryConfig = {
         }
     },
 
+    getLiveCategoryIdsForSave: function () {
+        const self = this;
+        // The category checkboxes only exist once the list has been loaded from the provider.
+        // Reading them before that returns an empty array, which would quietly rewrite a saved
+        // selection to "nothing ticked" - syncing no channels in Custom mode, or every channel
+        // in ExcludeSelected mode. Fall back to what was loaded from the config instead.
+        const rendered = document.querySelectorAll('input[data-category-type="live"]');
+        if (rendered.length === 0) {
+            return self.selectedLiveCategoryIds.slice();
+        }
+
+        return self.getSelectedCategoryIds('live');
+    },
+
     getSelectedCategoryIds: function (type) {
         const checkboxes = document.querySelectorAll('input[data-category-type="' + type + '"]:checked');
         const ids = [];
@@ -1748,21 +1764,45 @@ const XtreamLibraryConfig = {
         });
     },
 
+    getLiveChannelMode: function () {
+        const checked = document.querySelector('input[name="LiveChannelMode"]:checked');
+        return checked ? checked.value : 'IncludeAll';
+    },
+
     updateLiveCategoryCounter: function () {
         const counter = document.getElementById('liveCategoryCounter');
         if (!counter) return;
         const all = document.querySelectorAll('input[data-category-type="live"]');
         const checked = document.querySelectorAll('input[data-category-type="live"]:checked');
-        counter.textContent = checked.length + ' of ' + all.length + ' categories selected';
+        // A ticked box means the opposite thing in each mode, so "N of M selected" would read
+        // backwards in exclude mode: it is the unticked categories that get synced there.
+        if (XtreamLibraryConfig.getLiveChannelMode() === 'ExcludeSelected') {
+            counter.textContent = checked.length + ' of ' + all.length + ' categories excluded';
+        } else {
+            counter.textContent = checked.length + ' of ' + all.length + ' categories selected';
+        }
     },
 
     updateLiveChannelModeVisibility: function () {
-        const checked = document.querySelector('input[name="LiveChannelMode"]:checked');
-        const mode = checked ? checked.value : 'IncludeAll';
+        const mode = XtreamLibraryConfig.getLiveChannelMode();
         const customSection = document.getElementById('liveCustomSection');
         if (customSection) {
-            customSection.style.display = (mode === 'Custom') ? '' : 'none';
+            customSection.style.display = (mode === 'Custom' || mode === 'ExcludeSelected') ? '' : 'none';
         }
+
+        const hint = document.getElementById('liveChannelModeHint');
+        if (hint) {
+            if (mode === 'Custom') {
+                hint.textContent = 'Only the categories you tick are synced. Tick nothing and nothing syncs.';
+            } else if (mode === 'ExcludeSelected') {
+                hint.textContent = 'Everything is synced except the categories you tick, so categories your '
+                    + 'provider adds later are picked up automatically. Tick nothing and everything syncs.';
+            } else {
+                hint.textContent = '';
+            }
+        }
+
+        XtreamLibraryConfig.updateLiveCategoryCounter();
     },
 
     filterLiveCategoryList: function () {

--- a/Jellyfin.Xtream.Library/PluginConfiguration.cs
+++ b/Jellyfin.Xtream.Library/PluginConfiguration.cs
@@ -36,6 +36,18 @@ public enum LiveChannelSelectionMode
     /// Empty <see cref="PluginConfiguration.SelectedLiveCategoryIds"/> means zero channels (not "all").
     /// </summary>
     Custom,
+
+    /// <summary>
+    /// Sync every channel except those in the selected categories, minus per-channel exclusions.
+    /// <see cref="PluginConfiguration.SelectedLiveCategoryIds"/> is read as an exclusion list here.
+    /// Empty means every channel (excluding nothing excludes nothing) — the opposite of
+    /// <see cref="Custom"/>, and the same rule Movies and Series already follow (GitHub #76).
+    /// <para>
+    /// Deliberately appended last. Inserting a member above <see cref="Custom"/> would renumber it,
+    /// and any config not round-tripped by name would silently reinterpret Custom as this mode.
+    /// </para>
+    /// </summary>
+    ExcludeSelected,
 }
 
 /// <summary>
@@ -132,21 +144,27 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets how Live TV channel selection is interpreted.
     /// In <see cref="LiveChannelSelectionMode.IncludeAll"/> mode the selection arrays are ignored.
     /// In <see cref="LiveChannelSelectionMode.Custom"/> mode an empty <see cref="SelectedLiveCategoryIds"/>
-    /// means zero channels (not "all"). Defaults to <see cref="LiveChannelSelectionMode.IncludeAll"/>;
+    /// means zero channels (not "all"); in <see cref="LiveChannelSelectionMode.ExcludeSelected"/> mode
+    /// an empty one means every channel. Defaults to <see cref="LiveChannelSelectionMode.IncludeAll"/>;
     /// existing configs with populated selection state are migrated to <see cref="LiveChannelSelectionMode.Custom"/>
     /// on startup (see <c>Plugin.MigrateConfigurationIfNeeded</c>).
     /// </summary>
     public LiveChannelSelectionMode LiveChannelMode { get; set; } = LiveChannelSelectionMode.IncludeAll;
 
     /// <summary>
-    /// Gets or sets the array of selected Live TV category IDs.
-    /// Only honoured when <see cref="LiveChannelMode"/> is <see cref="LiveChannelSelectionMode.Custom"/>.
+    /// Gets or sets the array of Live TV category IDs the selection applies to.
+    /// Read as an inclusion list in <see cref="LiveChannelSelectionMode.Custom"/> mode and as an
+    /// exclusion list in <see cref="LiveChannelSelectionMode.ExcludeSelected"/> mode.
+    /// Ignored in <see cref="LiveChannelSelectionMode.IncludeAll"/> mode.
     /// </summary>
     public int[] SelectedLiveCategoryIds { get; set; } = Array.Empty<int>();
 
     /// <summary>
-    /// Gets or sets stream IDs to exclude from Live TV sync, even if their category is selected.
-    /// Only honoured when <see cref="LiveChannelMode"/> is <see cref="LiveChannelSelectionMode.Custom"/>.
+    /// Gets or sets stream IDs to exclude from Live TV sync, even if their category is in scope.
+    /// Honoured in <see cref="LiveChannelSelectionMode.Custom"/> and
+    /// <see cref="LiveChannelSelectionMode.ExcludeSelected"/> mode; ignored in
+    /// <see cref="LiveChannelSelectionMode.IncludeAll"/>, which is the "sync everything, no
+    /// exceptions" mode.
     /// </summary>
     public int[] ExcludedLiveStreamIds { get; set; } = Array.Empty<int>();
 

--- a/Jellyfin.Xtream.Library/Service/LiveTvService.cs
+++ b/Jellyfin.Xtream.Library/Service/LiveTvService.cs
@@ -335,8 +335,17 @@ public class LiveTvService : IDisposable
             result = result.Where(c => !c.IsAdult).ToList();
         }
 
+        // Category filtering is normally decided at fetch time by choosing which categories to
+        // request, so a snapshot cannot hold the wrong ones. ExcludeSelected breaks that: it fetches
+        // everything and narrows afterwards, so a snapshot taken before a category was excluded
+        // still contains it. Re-apply here for the same reason the adult filter is re-applied.
+        if (config.LiveChannelMode == LiveChannelSelectionMode.ExcludeSelected)
+        {
+            result = FilterExcludedCategories(result, config.SelectedLiveCategoryIds);
+        }
+
         // IncludeAll deliberately ignores per-channel exclusions, matching the fetch path.
-        if (config.LiveChannelMode == LiveChannelSelectionMode.Custom)
+        if (config.LiveChannelMode != LiveChannelSelectionMode.IncludeAll)
         {
             result = FilterExcludedChannels(result, config.ExcludedLiveStreamIds);
         }
@@ -701,8 +710,16 @@ public class LiveTvService : IDisposable
             providerChannels = providerChannels.Where(c => !c.IsAdult).ToList();
         }
 
-        // Apply per-channel exclusions only in Custom mode (IncludeAll deliberately ignores them).
-        if (config.LiveChannelMode == LiveChannelSelectionMode.Custom)
+        // ExcludeSelected fetched the whole catalogue above, so the category filter happens here
+        // rather than by choosing what to request. No-op in the other two modes.
+        if (config.LiveChannelMode == LiveChannelSelectionMode.ExcludeSelected)
+        {
+            providerChannels = FilterExcludedCategories(providerChannels, config.SelectedLiveCategoryIds);
+        }
+
+        // Apply per-channel exclusions in both selective modes (IncludeAll deliberately ignores
+        // them: it is the "everything, no exceptions" mode).
+        if (config.LiveChannelMode != LiveChannelSelectionMode.IncludeAll)
         {
             providerChannels = FilterExcludedChannels(providerChannels, config.ExcludedLiveStreamIds);
         }
@@ -735,9 +752,69 @@ public class LiveTvService : IDisposable
             return CategoryFetchStrategy.AllFromProvider;
         }
 
+        // ExcludeSelected fetches the whole catalogue and drops the excluded categories afterwards,
+        // so that categories the provider adds later are picked up on their own. It must not fall
+        // through to the count check below: that branch fetches *by* SelectedLiveCategoryIds, which
+        // in this mode would return exactly the categories the user asked to be rid of.
+        if (mode == LiveChannelSelectionMode.ExcludeSelected)
+        {
+            return CategoryFetchStrategy.AllFromProvider;
+        }
+
         return selectedCategoryCount == 0
             ? CategoryFetchStrategy.None
             : CategoryFetchStrategy.BySelectedCategories;
+    }
+
+    /// <summary>
+    /// Removes channels belonging to any of <paramref name="excludedCategoryIds"/>. Used only in
+    /// <see cref="LiveChannelSelectionMode.ExcludeSelected"/> mode, where the whole catalogue is
+    /// fetched and narrowed here instead of by asking the provider for specific categories.
+    /// </summary>
+    /// <param name="channels">Source list of channels.</param>
+    /// <param name="excludedCategoryIds">Category IDs to exclude. Null or empty returns the list unchanged,
+    /// because excluding nothing excludes nothing (GitHub #76 semantics).</param>
+    /// <returns>Filtered list of channels.</returns>
+    internal static List<LiveStreamInfo> FilterExcludedCategories(List<LiveStreamInfo> channels, int[]? excludedCategoryIds)
+    {
+        if (excludedCategoryIds == null || excludedCategoryIds.Length == 0)
+        {
+            return channels;
+        }
+
+        var excluded = new HashSet<int>(excludedCategoryIds);
+        return channels.Where(c => !IsInExcludedCategory(c, excluded)).ToList();
+    }
+
+    /// <summary>
+    /// True when any category the channel belongs to is excluded.
+    /// <para>
+    /// Membership is the union of the scalar primary category and the <c>category_ids</c> array,
+    /// because Include mode fetches per category and so pulls in a channel reachable through *any*
+    /// of its categories. Matching that union keeps Exclude the exact complement of Include on
+    /// providers that put one channel in several categories. A channel the provider gives no
+    /// category at all is kept: it is not in the exclusion list.
+    /// </para>
+    /// </summary>
+    private static bool IsInExcludedCategory(LiveStreamInfo channel, HashSet<int> excluded)
+    {
+        if (channel.CategoryId.HasValue && excluded.Contains(channel.CategoryId.Value))
+        {
+            return true;
+        }
+
+        if (channel.CategoryIds != null)
+        {
+            foreach (var categoryId in channel.CategoryIds)
+            {
+                if (excluded.Contains(categoryId))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Jellyfin.Xtream.Library/Service/Models/LiveChannelSnapshot.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/LiveChannelSnapshot.cs
@@ -159,6 +159,7 @@ public class LiveChannelSnapshot
                 Num = entry.Num,
                 Tags = entry.Tags,
                 CategoryId = entry.CategoryId,
+                CategoryIds = entry.CategoryIds,
                 TvArchive = entry.TvArchive,
                 TvArchiveDuration = entry.TvArchiveDuration,
                 ProviderIndex = entry.ProviderIndex,
@@ -289,6 +290,15 @@ public class LiveChannelSnapshotEntry
     public int? CategoryId { get; set; }
 
     /// <summary>
+    /// Gets or sets the channel's full category membership, on providers that report more than the
+    /// primary one. Persisted so the exclude-categories filter re-applied when rendering from a
+    /// snapshot sees the same membership the fetch-time filter did; without it a channel excluded
+    /// through a secondary category would survive until the next refresh. Older snapshots simply
+    /// have no value here, which reads as "primary category only". See GitHub #79.
+    /// </summary>
+    public int[]? CategoryIds { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the channel supports catch-up.
     /// </summary>
     public bool TvArchive { get; set; }
@@ -330,6 +340,7 @@ public class LiveChannelSnapshotEntry
             Tags = channel.Tags,
             Checksum = ComputeChecksum(channel),
             CategoryId = channel.CategoryId,
+            CategoryIds = channel.CategoryIds,
             TvArchive = channel.TvArchive,
             TvArchiveDuration = channel.TvArchiveDuration,
             ProviderIndex = channel.ProviderIndex,

--- a/tests/js/helpers/config-harness.js
+++ b/tests/js/helpers/config-harness.js
@@ -60,13 +60,20 @@ function folderItem(name, categoryIds) {
     });
 }
 
-/** Installs a document stub backed by the given id -> element map, and returns a restore function. */
-function withDocument(elementsById) {
+/**
+ * Installs a document stub backed by the given id -> element map, and returns a restore function.
+ *
+ * `selectors` optionally maps a CSS selector string to what the document-level query should
+ * return, for the functions that reach for checkboxes by attribute rather than by id. A selector
+ * with no entry resolves to nothing, which is the "not rendered yet" state.
+ */
+function withDocument(elementsById, selectors = {}) {
     const previous = global.document;
     global.document = {
         readyState: 'complete',
         getElementById: (id) => elementsById[id] || null,
-        querySelectorAll: () => [],
+        querySelectorAll: (selector) => selectors[selector] || [],
+        querySelector: (selector) => (selectors[selector] || [])[0] || null,
         addEventListener: () => {},
     };
     return () => {

--- a/tests/js/live-channel-mode.test.js
+++ b/tests/js/live-channel-mode.test.js
@@ -1,0 +1,166 @@
+// Copyright (C) 2024  Roland Breitschaft
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #79 added a third Live TV mode, ExcludeSelected, where the ticked categories are the ones
+// NOT synced. The same checkbox list now means opposite things depending on the mode, which is
+// exactly the kind of overloading that produced #78 - so the routes into a wrong selection are
+// pinned here.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { loadConfig, element, withDocument } = require('./helpers/config-harness');
+
+const LIVE_CHECKBOX_SELECTOR = 'input[data-category-type="live"]';
+const MODE_SELECTOR = 'input[name="LiveChannelMode"]:checked';
+
+/** A rendered category checkbox, as renderCategoryList would have drawn it. */
+function categoryCheckbox(id, checked) {
+    return element({
+        checked,
+        getAttribute: (attr) => (attr === 'data-category-id' ? String(id) : null),
+    });
+}
+
+/** The document-level selector map for a rendered live category list in the given mode. */
+function liveDom(mode, checkboxes) {
+    return {
+        [MODE_SELECTOR]: mode ? [element({ value: mode })] : [],
+        [LIVE_CHECKBOX_SELECTOR]: checkboxes,
+        [LIVE_CHECKBOX_SELECTOR + ':checked']: checkboxes.filter((c) => c.checked),
+    };
+}
+
+test('saving does not wipe the category selection before the list has loaded', async (t) => {
+    await t.test('an unrendered list falls back to what was loaded from the config', () => {
+        const config = loadConfig();
+        config.selectedLiveCategoryIds = [10, 20];
+        // No entry for the checkbox selector: the list has not been fetched from the provider yet.
+        const restore = withDocument({}, liveDom('ExcludeSelected', []));
+
+        try {
+            // Reading the empty DOM would save [], which in this mode means "exclude nothing"
+            // and floods the library with every channel the provider has.
+            assert.deepStrictEqual(config.getLiveCategoryIdsForSave(), [10, 20]);
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('the fallback is a copy, not the live array', () => {
+        const config = loadConfig();
+        config.selectedLiveCategoryIds = [10];
+        const restore = withDocument({}, liveDom('Custom', []));
+
+        try {
+            config.getLiveCategoryIdsForSave().push(999);
+            assert.deepStrictEqual(config.selectedLiveCategoryIds, [10]);
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('a rendered list wins over the loaded config, so unticking still saves', () => {
+        const config = loadConfig();
+        config.selectedLiveCategoryIds = [10, 20];
+        const checkboxes = [categoryCheckbox(10, true), categoryCheckbox(20, false)];
+        const restore = withDocument({}, liveDom('ExcludeSelected', checkboxes));
+
+        try {
+            assert.deepStrictEqual(config.getLiveCategoryIdsForSave(), [10]);
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('a rendered list with nothing ticked genuinely saves an empty selection', () => {
+        const config = loadConfig();
+        config.selectedLiveCategoryIds = [10];
+        const checkboxes = [categoryCheckbox(10, false), categoryCheckbox(20, false)];
+        const restore = withDocument({}, liveDom('Custom', checkboxes));
+
+        try {
+            // The guard must only cover "not loaded", never "loaded and deliberately cleared".
+            assert.deepStrictEqual(config.getLiveCategoryIdsForSave(), []);
+        } finally {
+            restore();
+        }
+    });
+});
+
+test('the category list is shown in both modes that read it', async (t) => {
+    const cases = [
+        { mode: 'IncludeAll', expected: 'none' },
+        { mode: 'Custom', expected: '' },
+        { mode: 'ExcludeSelected', expected: '' },
+    ];
+
+    for (const { mode, expected } of cases) {
+        await t.test(`${mode} sets the custom section display to "${expected}"`, () => {
+            const config = loadConfig();
+            const customSection = element({ style: { display: 'unset' } });
+            const restore = withDocument(
+                { liveCustomSection: customSection },
+                liveDom(mode, []));
+
+            try {
+                config.updateLiveChannelModeVisibility();
+                assert.strictEqual(customSection.style.display, expected);
+            } finally {
+                restore();
+            }
+        });
+    }
+
+    await t.test('no mode ticked at all falls back to IncludeAll', () => {
+        const config = loadConfig();
+        const customSection = element({ style: { display: 'unset' } });
+        const restore = withDocument({ liveCustomSection: customSection }, liveDom(null, []));
+
+        try {
+            config.updateLiveChannelModeVisibility();
+            assert.strictEqual(customSection.style.display, 'none');
+        } finally {
+            restore();
+        }
+    });
+});
+
+test('the counter says excluded or selected to match the mode', async (t) => {
+    await t.test('exclude mode counts what will NOT be synced', () => {
+        const config = loadConfig();
+        const counter = element({ textContent: '' });
+        const checkboxes = [categoryCheckbox(10, true), categoryCheckbox(20, false)];
+        const restore = withDocument(
+            { liveCategoryCounter: counter },
+            liveDom('ExcludeSelected', checkboxes));
+
+        try {
+            config.updateLiveCategoryCounter();
+            assert.strictEqual(counter.textContent, '1 of 2 categories excluded');
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('custom mode still counts what will be synced', () => {
+        const config = loadConfig();
+        const counter = element({ textContent: '' });
+        const checkboxes = [categoryCheckbox(10, true), categoryCheckbox(20, false)];
+        const restore = withDocument(
+            { liveCategoryCounter: counter },
+            liveDom('Custom', checkboxes));
+
+        try {
+            config.updateLiveCategoryCounter();
+            assert.strictEqual(counter.textContent, '1 of 2 categories selected');
+        } finally {
+            restore();
+        }
+    });
+});

--- a/tests/js/live-channel-mode.test.js
+++ b/tests/js/live-channel-mode.test.js
@@ -131,6 +131,89 @@ test('the category list is shown in both modes that read it', async (t) => {
     });
 });
 
+test('bulk category toggles do not destroy per-channel exclusions in exclude mode', async (t) => {
+    // In exclude mode, "Exclude none" means sync everything, and the per-channel exclusions are
+    // then the only filter left. The Custom-mode reasoning - that they are stale leftovers of a
+    // selection just replaced wholesale - does not hold, so they have to survive.
+    await t.test('deselect all keeps them in ExcludeSelected mode', () => {
+        const config = loadConfig();
+        config.excludedLiveStreamIds = [101, 102];
+        config.redrawExpandedLiveChannelPanels = () => {};
+        const restore = withDocument({}, liveDom('ExcludeSelected', []));
+
+        try {
+            config.deselectAllCategories('live');
+            assert.deepStrictEqual(config.excludedLiveStreamIds, [101, 102]);
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('select all keeps them in ExcludeSelected mode', () => {
+        const config = loadConfig();
+        config.excludedLiveStreamIds = [101];
+        config.redrawExpandedLiveChannelPanels = () => {};
+        const restore = withDocument({}, liveDom('ExcludeSelected', []));
+
+        try {
+            config.selectAllCategories('live');
+            assert.deepStrictEqual(config.excludedLiveStreamIds, [101]);
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('Custom mode still clears them, as before', () => {
+        const config = loadConfig();
+        config.excludedLiveStreamIds = [101, 102];
+        config.redrawExpandedLiveChannelPanels = () => {};
+        const restore = withDocument({}, liveDom('Custom', []));
+
+        try {
+            config.deselectAllCategories('live');
+            assert.deepStrictEqual(config.excludedLiveStreamIds, []);
+        } finally {
+            restore();
+        }
+    });
+});
+
+test('the bulk toggle buttons say what they actually do', async (t) => {
+    await t.test('exclude mode relabels them so "Select all" cannot read as "sync everything"', () => {
+        const config = loadConfig();
+        const selectAll = element({ textContent: 'Select all' });
+        const deselectAll = element({ textContent: 'Deselect all' });
+        const restore = withDocument(
+            { btnLiveSelectAllLabel: selectAll, btnLiveDeselectAllLabel: deselectAll },
+            liveDom('ExcludeSelected', []));
+
+        try {
+            config.updateLiveChannelModeVisibility();
+            assert.strictEqual(selectAll.textContent, 'Exclude all');
+            assert.strictEqual(deselectAll.textContent, 'Exclude none');
+        } finally {
+            restore();
+        }
+    });
+
+    await t.test('custom mode keeps the original labels', () => {
+        const config = loadConfig();
+        const selectAll = element({ textContent: '' });
+        const deselectAll = element({ textContent: '' });
+        const restore = withDocument(
+            { btnLiveSelectAllLabel: selectAll, btnLiveDeselectAllLabel: deselectAll },
+            liveDom('Custom', []));
+
+        try {
+            config.updateLiveChannelModeVisibility();
+            assert.strictEqual(selectAll.textContent, 'Select all');
+            assert.strictEqual(deselectAll.textContent, 'Deselect all');
+        } finally {
+            restore();
+        }
+    });
+});
+
 test('the counter says excluded or selected to match the mode', async (t) => {
     await t.test('exclude mode counts what will NOT be synced', () => {
         const config = loadConfig();


### PR DESCRIPTION
Closes #79.

Live TV could sync everything, or sync a ticked list, with no way to say "everything except these". Movies and Series got that in #75/#76. This is the Live TV half.

## Approach

Option (a) from the issue: a third member on `LiveChannelSelectionMode` rather than a second mode switch beside it, so there is still one source of truth for the mode and no way to land in a Custom+Exclude combination with no defined meaning.

`ExcludeSelected` reads `SelectedLiveCategoryIds` as an exclusion list. An empty one means every channel (excluding nothing excludes nothing), matching the #76 convention. That is the opposite of `Custom`'s empty-means-none rule, so it is pinned by a test rather than left for someone to "fix" by analogy later.

It fetches the whole catalogue and filters afterwards, which is what makes categories the provider adds later show up on their own. Two consequences of filtering late, both handled:

- `ChooseCategoryFetchStrategy` needs its own branch. Falling through to the Custom one would fetch *by* `SelectedLiveCategoryIds`, returning exactly the categories the user asked to be rid of, with nothing thrown.
- `ApplyRenderTimeFilters` needs the category filter too. Every other mode decides categories by choosing what to request, so a snapshot cannot hold the wrong ones. This one can, and would keep serving a category after it was excluded.

Per-channel exclusions now apply in both selective modes. `IncludeAll` still ignores them, unchanged, as the "everything, no exceptions" mode.

## Things found on the way

**`category_ids` nearly broke Live TV for everyone.** The field is mapped so Exclude is the exact complement of Include on providers that put one channel in several categories. But a plain `int[]` throws on any shape except a JSON array, and that happens inside the shared fetch path, so one such channel fails the whole request, including for `IncludeAll` and `Custom` users who never touch the new mode. Tests over the shapes providers actually send confirmed it: a bare scalar, a comma-separated string and a malformed element all threw. Same hazard the `added` field hit in #41, so it gets the same treatment, a lenient converter in the `StringBoolConverter` idiom.

**"Select all" was a one-click route to syncing nothing.** It ticks every category, which in the new mode excludes every category, while its own comment claimed the opposite. Both bulk toggles also cleared the per-channel exclusion list, which is sound in Custom mode (those exclusions only qualified a selection just replaced wholesale) but destroys real state in exclude mode, where "Exclude none" means sync everything and per-channel exclusions are the only filter left. Buttons now say Exclude all / Exclude none there, and the reset is confined to the mode where it makes sense.

**A pre-existing config page bug the new mode would have walked into.** The save path reads the selection straight off the checkboxes, and the category auto-load was gated on Custom. Saving before the list had rendered wrote an empty array. That is a silent "sync nothing" in Custom mode today, and would have been "sync everything" in the new one. Saving now falls back to the loaded config when the list was never rendered.

The enum member is appended rather than slotted next to `Custom`, so existing configs cannot be renumbered into the new mode. Pinned by a test.

## Verification

Checked against a real provider rather than assumed: `category_id` is populated on all 721 channels of the bulk endpoint, and arrives as a string, which Newtonsoft coerces.

654 .NET tests and 45 config page tests pass. Build is clean apart from one pre-existing warning in an untouched file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Exclude selected categories** mode for Live TV channels.
  * Added category-aware filtering, including secondary category memberships.
  * Preserved category selections and channel exclusions across configuration changes and snapshot restoration.
  * Improved handling of inconsistent provider category data.

* **Bug Fixes**
  * Prevented malformed category values from disrupting channel processing.
  * Ensured per-channel exclusions are applied consistently across supported modes.

* **Tests**
  * Added comprehensive coverage for category parsing, filtering, configuration persistence, and mode-specific interface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->