### PR TITLE
fix(config): trim whitespace off provider credentials (#84)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Client/ConnectionInfoTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Client/ConnectionInfoTests.cs
@@ -1,0 +1,78 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #84. A provider password saved with a trailing space was stored verbatim and interpolated
+// straight into every stream URL, producing ".../<password> /12345.mkv" and a 403 on every item.
+// The configuration page now trims the field, but that only helps a user who re-saves; trimming in
+// ConnectionInfo is what repairs configurations that already carry the whitespace, because every
+// caller that talks to the provider builds one of these first.
+
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Client;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Client;
+
+public class ConnectionInfoTests
+{
+    [Theory]
+    [InlineData("secret ")]
+    [InlineData(" secret")]
+    [InlineData("  secret  ")]
+    [InlineData("secret\t")]
+    [InlineData("secret\n")]
+    [InlineData("secret\u00A0")] // non-breaking space, the usual copy-paste artefact
+    public void Password_IsTrimmed(string stored)
+    {
+        new ConnectionInfo("http://host:8901", "user", stored).Password.Should().Be("secret");
+    }
+
+    [Fact]
+    public void BaseUrlAndUserName_AreTrimmed()
+    {
+        var info = new ConnectionInfo("  http://host:8901  ", " user ", "secret");
+
+        info.BaseUrl.Should().Be("http://host:8901");
+        info.UserName.Should().Be("user");
+    }
+
+    [Fact]
+    public void InteriorWhitespace_IsPreserved()
+    {
+        new ConnectionInfo("http://host:8901", "first last", " pass word ").Password.Should().Be("pass word");
+    }
+
+    [Fact]
+    public void WhitespaceOnlyValue_BecomesEmpty()
+    {
+        new ConnectionInfo("http://host:8901", "user", "   ").Password.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NullValue_BecomesEmpty()
+    {
+        // The XML configuration can deserialize an absent element to null, and the old code stored
+        // it as-is. Trimming must not turn that into a NullReferenceException mid-sync.
+        var info = new ConnectionInfo(null!, null!, null!);
+
+        info.BaseUrl.Should().BeEmpty();
+        info.UserName.Should().BeEmpty();
+        info.Password.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StreamUrl_HasNoStrayWhitespace()
+    {
+        // The exact shape the reporter saw: StrmSyncService interpolates these three values.
+        var info = new ConnectionInfo("http://host:8901", "user ", "secret ");
+
+        var url = $"{info.BaseUrl}/movie/{info.UserName}/{info.Password}/572499.mkv";
+
+        url.Should().Be("http://host:8901/movie/user/secret/572499.mkv");
+        url.Should().NotContain(" ");
+    }
+}

--- a/Jellyfin.Xtream.Library/Client/ConnectionInfo.cs
+++ b/Jellyfin.Xtream.Library/Client/ConnectionInfo.cs
@@ -21,22 +21,28 @@ namespace Jellyfin.Xtream.Library.Client;
 /// <param name="baseUrl">The base url including protocol and port number, without trailing slash.</param>
 /// <param name="username">The username for authentication.</param>
 /// <param name="password">The password for authentication.</param>
+/// <remarks>
+/// All three values are trimmed. Credentials are interpolated straight into stream URLs, so a
+/// stray space saved with the password produces ".../&lt;password&gt; /12345.mkv" and a 403 on every
+/// item. Trimming here rather than only in the configuration page also repairs configurations
+/// that were already saved with whitespace, without the user having to re-enter anything.
+/// </remarks>
 public class ConnectionInfo(string baseUrl, string username, string password)
 {
     /// <summary>
     /// Gets or sets the base url including protocol and port number, without trailing slash.
     /// </summary>
-    public string BaseUrl { get; set; } = baseUrl;
+    public string BaseUrl { get; set; } = (baseUrl ?? string.Empty).Trim();
 
     /// <summary>
     /// Gets or sets the username for authentication.
     /// </summary>
-    public string UserName { get; set; } = username;
+    public string UserName { get; set; } = (username ?? string.Empty).Trim();
 
     /// <summary>
     /// Gets or sets the password for authentication.
     /// </summary>
-    public string Password { get; set; } = password;
+    public string Password { get; set; } = (password ?? string.Empty).Trim();
 
     /// <inheritdoc />
     public override string ToString() => $"{BaseUrl} {UserName}:***";

--- a/Jellyfin.Xtream.Library/Client/DispatcharrClient.cs
+++ b/Jellyfin.Xtream.Library/Client/DispatcharrClient.cs
@@ -62,6 +62,11 @@ public class DispatcharrClient : IDispatcharrClient
     /// <inheritdoc />
     public void Configure(string username, string password)
     {
+        // Trimmed for the same reason as ConnectionInfo: whitespace saved with the credential
+        // otherwise reaches the JWT request and the login fails with no useful message.
+        username = (username ?? string.Empty).Trim();
+        password = (password ?? string.Empty).Trim();
+
         if (!string.Equals(_username, username, StringComparison.Ordinal) ||
             !string.Equals(_password, password, StringComparison.Ordinal))
         {

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -189,7 +189,7 @@ const XtreamLibraryConfig = {
 
         p.BaseUrl = document.getElementById('txtBaseUrl').value.trim().replace(/\/$/, '');
         p.Username = document.getElementById('txtUsername').value.trim();
-        p.Password = document.getElementById('txtPassword').value;
+        p.Password = document.getElementById('txtPassword').value.trim();
         p.UserAgent = document.getElementById('txtUserAgent').value.trim();
         p.LibraryPath = document.getElementById('txtLibraryPath').value.trim();
         p.SyncMovies = document.getElementById('chkSyncMovies').checked;
@@ -263,7 +263,7 @@ const XtreamLibraryConfig = {
 
         p.EnableDispatcharrMode = document.getElementById('chkEnableDispatcharrMode').checked;
         p.DispatcharrApiUser = document.getElementById('txtDispatcharrApiUser').value.trim();
-        p.DispatcharrApiPass = document.getElementById('txtDispatcharrApiPass').value;
+        p.DispatcharrApiPass = document.getElementById('txtDispatcharrApiPass').value.trim();
     },
 
     // Tab switching
@@ -730,7 +730,7 @@ const XtreamLibraryConfig = {
         const credentials = {
             BaseUrl: baseUrl,
             Username: document.getElementById('txtUsername').value.trim(),
-            Password: document.getElementById('txtPassword').value
+            Password: document.getElementById('txtPassword').value.trim()
         };
 
         fetch(ApiClient.getUrl('XtreamLibrary/TestConnection'), {

--- a/tests/js/provider-credentials-trim.test.js
+++ b/tests/js/provider-credentials-trim.test.js
@@ -1,0 +1,103 @@
+// Copyright (C) 2024  Roland Breitschaft
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #84. Every field read back by updateActiveProviderFromUI was trimmed except the two
+// password fields, so a password pasted with a trailing space was saved verbatim and ended up
+// interpolated into every STRM URL as ".../<password> /12345.mkv", giving a 403 on every item.
+//
+// The server side trims as well (ConnectionInfo), which is what repairs configurations already
+// saved with whitespace. This layer stops it being stored in the first place.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { loadConfig, element, withDocument } = require('./helpers/config-harness');
+
+/**
+ * updateActiveProviderFromUI reads 30-odd element ids and would throw on any it cannot find.
+ * Only the credential fields matter here, so back the lookup with a proxy that invents an empty
+ * stub for every other id. New fields on the form therefore cannot break this test.
+ */
+function fields(overrides) {
+    const cache = {};
+    return new Proxy({}, {
+        get(_target, id) {
+            if (typeof id !== 'string') {
+                return undefined;
+            }
+
+            if (!(id in cache)) {
+                cache[id] = element(Object.prototype.hasOwnProperty.call(overrides, id) ? overrides[id] : {});
+            }
+
+            return cache[id];
+        },
+    });
+}
+
+/** Runs updateActiveProviderFromUI against the given field values and returns the saved provider. */
+function readBack(overrides) {
+    const config = loadConfig();
+    config.providers = [{}];
+    config.activeProviderIndex = 0;
+
+    const restore = withDocument(fields(overrides));
+    try {
+        config.updateActiveProviderFromUI();
+    } finally {
+        restore();
+    }
+
+    return config.providers[0];
+}
+
+test('the provider password is trimmed before it is saved', async (t) => {
+    await t.test('a trailing space is stripped', () => {
+        assert.strictEqual(readBack({ txtPassword: { value: 'secret ' } }).Password, 'secret');
+    });
+
+    await t.test('leading and trailing whitespace is stripped', () => {
+        assert.strictEqual(readBack({ txtPassword: { value: '  secret\t' } }).Password, 'secret');
+    });
+
+    await t.test('a non-breaking space is stripped', () => {
+        // The usual artefact of copying credentials out of a provider's web page.
+        assert.strictEqual(readBack({ txtPassword: { value: 'secret\u00A0' } }).Password, 'secret');
+    });
+
+    await t.test('a whitespace-only value becomes empty', () => {
+        assert.strictEqual(readBack({ txtPassword: { value: '   ' } }).Password, '');
+    });
+
+    await t.test('whitespace inside the password is preserved', () => {
+        assert.strictEqual(readBack({ txtPassword: { value: ' pass word ' } }).Password, 'pass word');
+    });
+});
+
+test('the Dispatcharr API password is trimmed before it is saved', async (t) => {
+    await t.test('a trailing space is stripped', () => {
+        assert.strictEqual(readBack({ txtDispatcharrApiPass: { value: 'apipass ' } }).DispatcharrApiPass, 'apipass');
+    });
+
+    await t.test('the user field keeps the trimming it already had', () => {
+        assert.strictEqual(readBack({ txtDispatcharrApiUser: { value: ' admin ' } }).DispatcharrApiUser, 'admin');
+    });
+});
+
+test('the saved credentials cannot produce a stream URL with a stray space', () => {
+    const provider = readBack({
+        txtBaseUrl: { value: 'http://host:8901 ' },
+        txtUsername: { value: 'user ' },
+        txtPassword: { value: 'secret ' },
+    });
+
+    const url = `${provider.BaseUrl}/movie/${provider.Username}/${provider.Password}/572499.mkv`;
+
+    assert.strictEqual(url, 'http://host:8901/movie/user/secret/572499.mkv');
+    assert.ok(!url.includes(' '), 'stream URL must not contain a space');
+});


### PR DESCRIPTION
## The bug

A provider password saved with a trailing space was stored verbatim and interpolated straight into every stream URL, so FFmpeg resolved `.../<password> /12345.mkv` and every item failed with `403 Forbidden`. Every other field on the provider form was already trimmed. The two password fields were not.

## The fix

Trim the password fields in the config page, and also in `ConnectionInfo` and `DispatcharrClient.Configure`.

The server-side trim is the part that matters for anyone already affected. A config-page fix only helps a user who goes back and re-saves the password, while every caller that talks to a provider builds a `ConnectionInfo` first, so an existing configuration is repaired on the next sync with nothing to re-enter. `ConnectionInfo` is the single funnel for all 12 call sites; Dispatcharr credentials do not pass through it, hence the second site.

Both layers handle a non-breaking space, the usual artefact of pasting credentials out of a web page, and a null value stays empty rather than throwing.

## Tests

`ConnectionInfoTests` (11 cases, including the exact URL shape from the report) and `tests/js/provider-credentials-trim.test.js` (14 cases). 665 .NET tests and 62 config-page tests pass.

Reported by jamillejh. Fixes #84.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Leading and trailing whitespace is now removed from provider URLs, usernames, and passwords when connecting or saving configuration.
  - Passwords are cleaned before connection tests and authentication requests, improving reliability when credentials are copied with extra spaces.
  - Stream URLs no longer include unintended whitespace from provider details.
  - Empty or null connection values are handled safely, while whitespace within values remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->