### PR TITLE
fix(sync): stop a failed metadata fetch stripping a multi-version NFO (#90)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
@@ -307,23 +307,98 @@ public class StrmNameCollisionTests : IDisposable
             .Should().HaveCount(1);
     }
 
+    // GitHub #90. Every version of a title (V1/V2/V3) resolves to one folder and therefore to one
+    // "<folder>.nfo", while the STRM files keep their version label and stay distinct. So the STRM
+    // claim never fires here and the NFO write was unguarded: whichever version finished last won,
+    // including a version whose metadata fetch had failed and had nothing to write.
+
+    private const string RaceNfo = "Race Movie (2024).nfo";
+
+    private static StreamInfo RaceVersion(int streamId, string label)
+        => new() { StreamId = streamId, Name = $"Race Movie (2024) - [{label}]", ContainerExtension = "mp4" };
+
+    private string RaceNfoPath => Path.Combine(_libraryPath, "Movies", "Race Movie (2024)", RaceNfo);
+
+    private void VodInfoReturns(int streamId, string plot)
+        => _client.Setup(c => c.GetVodInfoAsync(It.IsAny<ConnectionInfo>(), streamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VodInfoResponse { Info = new VodInfoDetails { Plot = plot } });
+
+    private void VodInfoFails(int streamId)
+        => _client.Setup(c => c.GetVodInfoAsync(It.IsAny<ConnectionInfo>(), streamId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("provider refused the info call"));
+
+    [Fact]
+    public async Task AVersionAddedLaterWhoseFetchFails_DoesNotStripTheExistingNfo()
+    {
+        VodInfoReturns(100, "The good plot");
+        VodInfoFails(200);
+
+        await RunMovieSyncAsync([RaceVersion(100, "V1")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+        (await File.ReadAllTextAsync(RaceNfoPath).ConfigureAwait(true))
+            .Should().Contain("The good plot", "the first run had working metadata");
+
+        // The provider adds V2 later and its info call fails. V2 is the only stream created this
+        // run, so it is the one that reaches the NFO write, with nothing to put in it.
+        await RunMovieSyncAsync([RaceVersion(100, "V1"), RaceVersion(200, "V2")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+
+        (await File.ReadAllTextAsync(RaceNfoPath).ConfigureAwait(true))
+            .Should().Contain("The good plot", "a failed fetch must not replace an NFO that already had metadata");
+        _log.Should().Contain(l => l.StartsWith("[Warning] Keeping the existing NFO", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheFailingVersionRunningFirst_StillLeavesTheRichNfo()
+    {
+        // A plain first-writer-wins claim would lock in the empty NFO here, because the version
+        // that cannot fetch anything is the one that takes the path.
+        VodInfoFails(100);
+        VodInfoReturns(200, "The good plot");
+
+        await RunMovieSyncAsync([RaceVersion(100, "V1"), RaceVersion(200, "V2")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+
+        (await File.ReadAllTextAsync(RaceNfoPath).ConfigureAwait(true))
+            .Should().Contain("The good plot", "the version with real metadata has to win regardless of order");
+    }
+
+    [Fact]
+    public async Task AFailedFetchWithNothingElseKnown_WritesNoNfoAndSaysWhy()
+    {
+        VodInfoFails(100);
+
+        var result = await RunMovieSyncAsync([RaceVersion(100, "V1")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+
+        // NfoWriter already refuses to write a file with no TMDB id, no media info and no metadata,
+        // so the outcome here is no NFO rather than an empty one. What changed is that the reason is
+        // now visible instead of being logged at Debug.
+        File.Exists(RaceNfoPath).Should().BeFalse("there was nothing to put in it");
+        result.Errors.Should().Be(0, "a provider that will not answer the info call is not a sync failure");
+        _log.Should().Contain(l => l.StartsWith("[Warning] Failed to fetch VOD info for NFO", StringComparison.Ordinal));
+    }
+
     private Task<SyncResult> RunMovieSyncAsync(params StreamInfo[] streams)
         => RunMovieSyncAsync(streams, useShippedDefaults: false);
 
-    private async Task<SyncResult> RunMovieSyncAsync(StreamInfo[] streams, bool useShippedDefaults)
+    private async Task<SyncResult> RunMovieSyncAsync(StreamInfo[] streams, bool useShippedDefaults, bool proactiveMediaInfo = false)
     {
         _client.Setup(c => c.GetVodCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Movies" } });
         _client.Setup(c => c.GetVodStreamsByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<StreamInfo>(streams));
 
-        return await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults).ConfigureAwait(true);
+        return await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults, providerCount: 1, proactiveMediaInfo).ConfigureAwait(true);
     }
 
     private Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults)
         => RunSyncAsync(syncMovies, syncSeries, useShippedDefaults, providerCount: 1);
 
-    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount)
+    private Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount)
+        => RunSyncAsync(syncMovies, syncSeries, useShippedDefaults, providerCount, proactiveMediaInfo: false);
+
+    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount, bool proactiveMediaInfo)
     {
         var appPaths = new Mock<IServerApplicationPaths>();
         appPaths.Setup(p => p.PluginConfigurationsPath).Returns(_libraryPath);
@@ -348,6 +423,7 @@ public class StrmNameCollisionTests : IDisposable
             EnableIncrementalSync = useShippedDefaults,
             SmartSkipExisting = useShippedDefaults,
             DownloadArtworkForUnmatched = false,
+            EnableProactiveMediaInfo = proactiveMediaInfo,
             SyncParallelism = 1,
         }).ToList();
         plugin.Configuration.EnableLiveTv = false;

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -612,7 +612,7 @@ public partial class StrmSyncService
         // would refuse a legitimate write. Case-insensitively they are one file, and not folding
         // them would hand out two claims and let the second silently overwrite the first, which
         // is the exact bug this guard exists to stop.
-        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(PathClaimComparer);
+        var claimedPaths = new ConcurrentDictionary<string, byte>(PathClaimComparer);
 
         // Check if sync is suppressed (e.g., after CleanLibraries)
         if (_syncSuppressed)
@@ -686,7 +686,7 @@ public partial class StrmSyncService
                     CurrentProgress.Phase = $"Provider {i + 1}/{enabledProviders.Count}: {provider.Name}";
                 }
 
-                var providerResult = await SyncProviderAsync(providerIndex, provider, claimedStrmPaths, linkedToken).ConfigureAwait(false);
+                var providerResult = await SyncProviderAsync(providerIndex, provider, claimedPaths, linkedToken).ConfigureAwait(false);
                 MergeResult(globalResult, providerResult);
             }
 
@@ -872,14 +872,16 @@ public partial class StrmSyncService
     /// </summary>
     /// <param name="providerIndex">Zero-based index of this provider in the Providers list.</param>
     /// <param name="provider">The provider configuration.</param>
-    /// <param name="claimedStrmPaths">STRM paths already written during this sync run, shared across providers.</param>
+    /// <param name="claimedPaths">File paths already written during this sync run, shared across providers.
+/// Covers STRM files and the NFO next to them: both are written from the parallel movie and episode
+/// loops, and both can be targeted by more than one stream (GitHub #80, #90).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The sync result for this provider.</returns>
 #pragma warning disable CA5351
     private async Task<SyncResult> SyncProviderAsync(
         int providerIndex,
         ProviderConfig provider,
-        ConcurrentDictionary<string, byte> claimedStrmPaths,
+        ConcurrentDictionary<string, byte> claimedPaths,
         CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTime.UtcNow };
@@ -998,7 +1000,7 @@ public partial class StrmSyncService
                             provider,
                             moviesPath,
                             syncedFiles,
-                            claimedStrmPaths,
+                            claimedPaths,
                             result,
                             previousSnapshot,
                             allCollectedMovies,
@@ -1016,7 +1018,7 @@ public partial class StrmSyncService
                         await SyncSeriesAsync(
                             provider,
                             seriesPath,
-                            claimedStrmPaths,
+                            claimedPaths,
                             syncedFiles,
                             result,
                             previousSnapshot,
@@ -1040,7 +1042,7 @@ public partial class StrmSyncService
                     provider,
                     moviesPath,
                     syncedFiles,
-                    claimedStrmPaths,
+                    claimedPaths,
                     result,
                     previousSnapshot,
                     allCollectedMovies,
@@ -1053,7 +1055,7 @@ public partial class StrmSyncService
                 await SyncSeriesAsync(
                     provider,
                     seriesPath,
-                    claimedStrmPaths,
+                    claimedPaths,
                     syncedFiles,
                     result,
                     previousSnapshot,
@@ -1402,7 +1404,7 @@ public partial class StrmSyncService
         ProviderConfig provider,
         string moviesPath,
         ConcurrentDictionary<string, byte> syncedFiles,
-        ConcurrentDictionary<string, byte> claimedStrmPaths,
+        ConcurrentDictionary<string, byte> claimedPaths,
         SyncResult result,
         ContentSnapshot? previousSnapshot,
         ConcurrentBag<StreamInfo> allCollectedMovies,
@@ -2024,7 +2026,7 @@ public partial class StrmSyncService
                         // File.Exists branch below compares content against a URL that embeds the
                         // stream id, so it can never match across two streams and always falls
                         // through to the overwrite. Refuse instead, and count it.
-                        if (!claimedStrmPaths.TryAdd(strmPath, 0))
+                        if (!claimedPaths.TryAdd(strmPath, 0))
                         {
                             Interlocked.Increment(ref nameCollisions);
                             _logger.LogWarning(
@@ -2071,7 +2073,7 @@ public partial class StrmSyncService
                             // file. Keeping it after a failed create would refuse a later duplicate
                             // that might have succeeded, and the name would end up with no STRM at
                             // all. Hand it back and let the original handler count the error.
-                            claimedStrmPaths.TryRemove(strmPath, out _);
+                            claimedPaths.TryRemove(strmPath, out _);
                             throw;
                         }
 
@@ -2088,6 +2090,7 @@ public partial class StrmSyncService
                             VideoInfo? nfoVideo = null;
                             AudioInfo? nfoAudio = null;
                             int? nfoDurationSecs = null;
+                            bool vodInfoFetchFailed = false;
 
                             if (enableProactiveMediaInfo)
                             {
@@ -2104,33 +2107,91 @@ public partial class StrmSyncService
                                     nfoAudio = vodInfo?.Info?.Audio;
                                     nfoDurationSecs = vodInfo?.Info?.DurationSecs;
                                 }
+                                catch (OperationCanceledException)
+                                {
+                                    throw;
+                                }
                                 catch (Exception ex)
                                 {
-                                    _logger.LogDebug(ex, "Failed to fetch VOD info for NFO: {StreamId}", stream.StreamId);
+                                    // Debug hid this: the write below still went ahead, just without plot,
+                                    // genre, cast or artwork, and overwrote whatever a sibling version had
+                                    // already written (GitHub #90). It is a Warning because the NFO that
+                                    // results is measurably worse than the one the provider could give.
+                                    vodInfoFetchFailed = true;
+                                    _logger.LogWarning(ex, "Failed to fetch VOD info for NFO: {StreamId}", stream.StreamId);
                                 }
                             }
 
                             var nfoPath = Path.Combine(movieFolder, $"{folderName}.nfo");
-                            await NfoWriter.WriteMovieNfoAsync(
-                                nfoPath,
-                                movieName,
-                                nfoVideo,
-                                nfoAudio,
-                                nfoDurationSecs,
-                                effectiveTmdbId,
-                                year,
-                                ct,
-                                plot: vodInfo?.Info?.Plot,
-                                genre: vodInfo?.Info?.Genre,
-                                director: vodInfo?.Info?.Director,
-                                cast: vodInfo?.Info?.Cast,
-                                country: vodInfo?.Info?.Country,
-                                rating: vodInfo?.Info?.Rating,
-                                premiered: vodInfo?.Info?.ReleaseDate,
-                                youtubeTrailerId: vodInfo?.Info?.YoutubeTrailer,
-                                dateAdded: AddedDateParser.Parse(stream.Added),
-                                posterUrl: vodInfo?.Info?.MovieImage ?? stream.StreamIcon,
-                                backdropUrl: vodInfo?.Info?.BackdropPaths.FirstOrDefault()).ConfigureAwait(false);
+
+                            // Every version of a title (V1/V2/V3) resolves to the same folder and so to
+                            // this same NFO path, and they are processed concurrently. Two guards, both
+                            // from GitHub #90:
+                            //
+                            // A failed metadata fetch must not replace a good file. The write would
+                            // otherwise go ahead with plot, cast and artwork missing and win by being
+                            // last. This one also holds across runs, which the claim below cannot.
+                            if (vodInfoFetchFailed && File.Exists(nfoPath))
+                            {
+                                _logger.LogWarning(
+                                    "Keeping the existing NFO for {MovieName}: metadata fetch failed for stream {StreamId}, so writing would strip it",
+                                    baseName,
+                                    stream.StreamId);
+                            }
+                            else if (!claimedPaths.TryAdd(nfoPath, 0))
+                            {
+                                // A sibling version already wrote it in this run. NfoWriter truncates and
+                                // rewrites, so letting both through interleaves them into a short file.
+                                _logger.LogDebug(
+                                    "NFO {NfoPath} already written by another stream in this run; stream {StreamId} skips it",
+                                    nfoPath,
+                                    stream.StreamId);
+                            }
+                            else
+                            {
+                                bool nfoWritten;
+                                try
+                                {
+                                    nfoWritten = await NfoWriter.WriteMovieNfoAsync(
+                                    nfoPath,
+                                    movieName,
+                                    nfoVideo,
+                                    nfoAudio,
+                                    nfoDurationSecs,
+                                    effectiveTmdbId,
+                                    year,
+                                    ct,
+                                    plot: vodInfo?.Info?.Plot,
+                                    genre: vodInfo?.Info?.Genre,
+                                    director: vodInfo?.Info?.Director,
+                                    cast: vodInfo?.Info?.Cast,
+                                    country: vodInfo?.Info?.Country,
+                                    rating: vodInfo?.Info?.Rating,
+                                    premiered: vodInfo?.Info?.ReleaseDate,
+                                    youtubeTrailerId: vodInfo?.Info?.YoutubeTrailer,
+                                    dateAdded: AddedDateParser.Parse(stream.Added),
+                                    posterUrl: vodInfo?.Info?.MovieImage ?? stream.StreamIcon,
+                                    backdropUrl: vodInfo?.Info?.BackdropPaths.FirstOrDefault()).ConfigureAwait(false);
+                                }
+                                catch
+                                {
+                                    // Same reasoning as the STRM claim: a claim is only worth holding
+                                    // once the file exists, otherwise a later version that could have
+                                    // succeeded is refused and the folder ends up with no NFO at all.
+                                    claimedPaths.TryRemove(nfoPath, out _);
+                                    throw;
+                                }
+
+                                if (vodInfoFetchFailed || !nfoWritten)
+                                {
+                                    // Either this stream had nothing to write, or NfoWriter decided
+                                    // there was not enough data to be worth a file. Holding the claim
+                                    // would make the outcome depend on which version happened to run
+                                    // first; releasing it lets a sibling with real metadata write,
+                                    // while the File.Exists guard above stops the reverse.
+                                    claimedPaths.TryRemove(nfoPath, out _);
+                                }
+                            }
                         }
 
                         // Download artwork for unmatched movies (only for first target folder)
@@ -2234,7 +2295,7 @@ public partial class StrmSyncService
     private async Task SyncSeriesAsync(
         ProviderConfig provider,
         string seriesPath,
-        ConcurrentDictionary<string, byte> claimedStrmPaths,
+        ConcurrentDictionary<string, byte> claimedPaths,
         ConcurrentDictionary<string, byte> syncedFiles,
         SyncResult result,
         ContentSnapshot? previousSnapshot,
@@ -3003,7 +3064,7 @@ public partial class StrmSyncService
                                 // File.Exists branch below cannot tell them apart, because it
                                 // compares against a URL carrying the episode id, so it would
                                 // silently overwrite. Refuse and count instead.
-                                if (!claimedStrmPaths.TryAdd(strmPath, 0))
+                                if (!claimedPaths.TryAdd(strmPath, 0))
                                 {
                                     Interlocked.Increment(ref episodeNameCollisions);
 
@@ -3058,7 +3119,7 @@ public partial class StrmSyncService
                                     // See the movie path: a claim is only worth holding once the
                                     // file exists, otherwise a later duplicate that could have
                                     // succeeded is refused and the name gets no STRM at all.
-                                    claimedStrmPaths.TryRemove(strmPath, out _);
+                                    claimedPaths.TryRemove(strmPath, out _);
                                     throw;
                                 }
 


### PR DESCRIPTION
## The bug

A title the provider offers as several version streams (V1/V2/V3) resolves to one folder, and therefore to one `<folder>.nfo`. The STRM files keep their version label so they stay distinct, which means the path claim added in #80 never fires here.

The versions are processed concurrently by `Parallel.ForEachAsync`, and `NfoWriter` truncates and rewrites unconditionally, so two writers can interleave into a short file. Worse, each version fetches `GetVodInfoAsync` independently and a failure was swallowed at Debug: that version still wrote its NFO, just without plot, genre, cast or artwork, and won by finishing last. One failed call replaced a complete NFO with a stub.

The race predates #87. Before it the NFO held only title, year and uniqueid, so the writers produced near-identical bytes and the loss was invisible.

## The fix

Three changes in the movie path:

- The NFO path is claimed the same way the STRM path is, so two versions cannot truncate the same file at once.
- A version whose fetch failed does not write over an NFO that already exists. This is the part that holds across runs, which a per-run claim cannot.
- The claim is released when the write was degraded or wrote nothing, so the version with real metadata wins regardless of which one ran first. Without this, a plain first-writer-wins claim would lock in the stub whenever the failing version happened to be scheduled first.

The swallowed failure is now a Warning, and a cancellation during the fetch is rethrown rather than being reported as a fetch failure.

## Not changed: the episode path

The issue lists episodes as having the same shape. They do not. An episode's NFO name is derived from the episode file name, which keeps the version label, so two episode NFOs collide only when their STRM files also collide, and the #80 claim already refuses that case before the NFO write is reached.

## Tests

Three regression tests on the existing sync harness: a version added later whose fetch fails does not strip the NFO an earlier run wrote; the failing version running first still leaves the rich NFO; and a failed fetch with nothing else known writes no NFO but now says why. 668 tests pass.

Reported by andreadegiovine. Fixes #90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of movie versions sharing a folder to prevent NFO files from being overwritten incorrectly.
  * Preserved existing NFO metadata when fetching updated media information fails.
  * Ensured versions with valid metadata take precedence regardless of processing order.
  * Prevented empty NFO files from being created when no metadata is available.
  * Added warning logs when media information retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->