### PR TITLE
feat(livetv): group channel numbers by category (#86)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/ChannelNumberingTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/ChannelNumberingTests.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #86. Providers number channels from 1 within each category, so the raw number is neither
+// a useful sort key across categories nor unique.
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Client.Models;
+using Jellyfin.Xtream.Library.Service;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class ChannelNumberingTests
+{
+    private static LiveStreamInfo Channel(int num, int? categoryId) =>
+        new() { StreamId = num, Name = $"Channel {num}", Num = num, CategoryId = categoryId };
+
+    [Fact]
+    public void Stride_DefaultsToAThousand_WhenChannelNumbersAreSmall()
+    {
+        ChannelNumbering.ComputeStride([Channel(1, 10), Channel(999, 10)])
+            .Should().Be(ChannelNumbering.MinimumStride);
+    }
+
+    [Fact]
+    public void Stride_Widens_SoNoCategoryCanSpillIntoTheNext()
+    {
+        // A provider numbering a channel 1000 would otherwise land it on top of category+1's first
+        // channel.
+        ChannelNumbering.ComputeStride([Channel(1, 10), Channel(1000, 10)]).Should().Be(10000);
+        ChannelNumbering.ComputeStride([Channel(45678, 10)]).Should().Be(100000);
+    }
+
+    [Fact]
+    public void Resolve_PrefixesTheCategoryId()
+    {
+        ChannelNumbering.Resolve(Channel(7, 3), 1000, byCategory: true).Should().Be(3007);
+    }
+
+    [Fact]
+    public void Resolve_LeavesTheNumberAlone_WhenTheFeatureIsOff()
+    {
+        ChannelNumbering.Resolve(Channel(7, 3), 1000, byCategory: false).Should().Be(7);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(-1)]
+    public void Resolve_LeavesTheNumberAlone_WhenThereIsNoCategoryToGroupBy(int? categoryId)
+    {
+        ChannelNumbering.Resolve(Channel(7, categoryId), 1000, byCategory: true).Should().Be(7);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToTheRawNumber_RatherThanOverflowing()
+    {
+        // Reported category ids already reach the 8000s; a widened stride on top of that can leave
+        // the int range, and a wrapped number would tune the wrong channel.
+        ChannelNumbering.Resolve(Channel(1, 9000), ChannelNumbering.MaximumStride, byCategory: true)
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public void Resolve_KeepsARealisticProviderInsideTheIntRange()
+    {
+        // The shape the reporter described: category ids in the 8000s.
+        ChannelNumbering.Resolve(Channel(12, 8123), 1000, byCategory: true).Should().Be(8123012);
+    }
+
+    [Fact]
+    public void TwoCategoriesNumberingFromOne_NoLongerCollide()
+    {
+        // This is the correctness half. The number is the key the tuner resolves hdhr_<number>
+        // back to a stream with, so a duplicate makes one of the two channels unreachable.
+        var sports = Channel(1, 5);
+        var news = Channel(1, 6);
+
+        var stride = ChannelNumbering.ComputeStride([sports, news]);
+
+        ChannelNumbering.Resolve(sports, stride, byCategory: true)
+            .Should().NotBe(ChannelNumbering.Resolve(news, stride, byCategory: true));
+    }
+
+    [Fact]
+    public void Ordering_GroupsEachCategoryTogether()
+    {
+        var channels = new List<LiveStreamInfo>
+        {
+            Channel(1, 20), Channel(1, 10), Channel(2, 20), Channel(2, 10),
+        };
+        var stride = ChannelNumbering.ComputeStride(channels);
+
+        var ordered = channels
+            .OrderBy(c => ChannelNumbering.Resolve(c, stride, byCategory: true))
+            .Select(c => (c.CategoryId, c.Num))
+            .ToList();
+
+        ordered.Should().Equal([(10, 1), (10, 2), (20, 1), (20, 2)]);
+    }
+}

--- a/Jellyfin.Xtream.Library.Tests/Service/XtreamTunerHostTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/XtreamTunerHostTests.cs
@@ -193,6 +193,57 @@ public class XtreamTunerHostTests : IDisposable
         result[2].ImageUrl.Should().Be("http://127.0.0.1:8096/XtreamLibrary/ChannelLogo/300");
     }
 
+    // GitHub #86. The channel number is both the guide's sort key and the key the tuner resolves
+    // hdhr_<number> back to a stream with, so a provider that numbers from 1 inside every category
+    // interleaves the guide and, worse, makes one of two same-numbered channels unreachable.
+    [Fact]
+    public async Task GetChannels_PrefixesTheCategoryId_WhenNumberByCategoryIsEnabled()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.EnableLiveTv = true;
+        config.EnableNativeTuner = true;
+        config.EnableChannelNameCleaning = false;
+        config.LiveTvNumberByCategory = true;
+
+        _mockClient
+            .Setup(c => c.GetAllLiveStreamsAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveStreamInfo>
+            {
+                new() { StreamId = 100, Name = "Sports One", Num = 1, CategoryId = 5 },
+                new() { StreamId = 200, Name = "News One", Num = 1, CategoryId = 6 },
+                new() { StreamId = 300, Name = "Sports Two", Num = 2, CategoryId = 5 },
+            });
+
+        var result = await _tunerHost.GetChannels(false, CancellationToken.None);
+
+        result.Select(c => c.Number).Should().Equal("5001", "6001", "5002");
+        result.Select(c => c.Number).Should().OnlyHaveUniqueItems(
+            "a duplicate number silently makes one of the two channels unreachable");
+    }
+
+    [Fact]
+    public async Task GetChannels_KeepsProviderNumbers_WhenNumberByCategoryIsOff()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.EnableLiveTv = true;
+        config.EnableNativeTuner = true;
+        config.EnableChannelNameCleaning = false;
+        config.LiveTvNumberByCategory = false;
+
+        _mockClient
+            .Setup(c => c.GetAllLiveStreamsAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveStreamInfo>
+            {
+                new() { StreamId = 100, Name = "Sports One", Num = 1, CategoryId = 5 },
+                new() { StreamId = 200, Name = "News One", Num = 1, CategoryId = 6 },
+            });
+
+        var result = await _tunerHost.GetChannels(false, CancellationToken.None);
+
+        // Unchanged behaviour for anyone who does not turn the option on, collision included.
+        result.Select(c => c.Number).Should().Equal("1", "1");
+    }
+
     // BUG-011: native tuner channels were ungrouped because ChannelGroup was never set.
     [Fact]
     public async Task GetChannels_SetsChannelGroup_FromCategoryName()

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -1037,6 +1037,24 @@
                         </div>
 
                         <div class="verticalSection">
+                            <h3 class="sectionTitle">Channel Order</h3>
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input is="emby-checkbox" type="checkbox" id="chkLiveTvNumberByCategory" name="LiveTvNumberByCategory" />
+                                    <span>Group channel numbers by category</span>
+                                </label>
+                                <div class="fieldDescription checkboxFieldDescription">
+                                    Providers number channels from 1 inside every category, so channel 1 of Sports,
+                                    News and Movies all end up next to each other in the guide. Turn this on to put
+                                    the category in front of the number, so each category's channels stay together.
+                                    This also stops two channels sharing a number, which could make one of them
+                                    unreachable.
+                                    <br />
+                                    Every channel gets a new number, so refresh the guide after changing this.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="verticalSection">
                             <h3 class="sectionTitle">Title Cleaning</h3>
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -338,6 +338,7 @@ const XtreamLibraryConfig = {
 
             // Title cleaning
             document.getElementById('chkEnableChannelNameCleaning').checked = config.EnableChannelNameCleaning !== false;
+            document.getElementById('chkLiveTvNumberByCategory').checked = config.LiveTvNumberByCategory === true;
             document.getElementById('txtChannelRemoveTerms').value = config.ChannelRemoveTerms || '';
 
             // Channel overrides
@@ -422,6 +423,7 @@ const XtreamLibraryConfig = {
 
             // Title cleaning
             config.EnableChannelNameCleaning = document.getElementById('chkEnableChannelNameCleaning').checked;
+            config.LiveTvNumberByCategory = document.getElementById('chkLiveTvNumberByCategory').checked;
             config.ChannelRemoveTerms = document.getElementById('txtChannelRemoveTerms').value;
 
             // Channel overrides

--- a/Jellyfin.Xtream.Library/PluginConfiguration.cs
+++ b/Jellyfin.Xtream.Library/PluginConfiguration.cs
@@ -209,6 +209,16 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool EnableChannelNameCleaning { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether channel numbers are prefixed with the category id
+    /// so the guide groups by category (GitHub #86).
+    /// <para>
+    /// Off by default: turning it on renumbers every channel, and Jellyfin keeps the old numbers in
+    /// its own database until the guide is refreshed.
+    /// </para>
+    /// </summary>
+    public bool LiveTvNumberByCategory { get; set; }
+
+    /// <summary>
     /// Gets or sets custom terms to remove from channel names. One term per line.
     /// </summary>
     public string ChannelRemoveTerms { get; set; } = string.Empty;

--- a/Jellyfin.Xtream.Library/Service/ChannelNumbering.cs
+++ b/Jellyfin.Xtream.Library/Service/ChannelNumbering.cs
@@ -1,0 +1,97 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using Jellyfin.Xtream.Library.Client.Models;
+
+namespace Jellyfin.Xtream.Library.Service;
+
+/// <summary>
+/// Builds the channel number Jellyfin sorts and tunes by (GitHub #86).
+/// <para>
+/// Providers number channels from 1 within each category, so the raw number is not unique across a
+/// multi-category selection. Two things follow. The guide interleaves categories, because Jellyfin
+/// sorts on the number rather than on the group. And the number is the key
+/// <see cref="XtreamTunerHost"/> resolves <c>hdhr_&lt;number&gt;</c> back to a stream with, so a
+/// duplicate silently makes one of the two channels unreachable.
+/// </para>
+/// <para>
+/// Prefixing the category id fixes both. The category id is used rather than a running index so the
+/// numbers stay stable when the provider adds a category later.
+/// </para>
+/// </summary>
+internal static class ChannelNumbering
+{
+    /// <summary>
+    /// Smallest room reserved per category. Widened when a provider numbers channels beyond it.
+    /// </summary>
+    internal const int MinimumStride = 1000;
+
+    /// <summary>
+    /// Ceiling for the stride. A stride beyond this leaves no room for the category id inside an
+    /// int, and channel numbers are an int all the way through Jellyfin.
+    /// </summary>
+    internal const int MaximumStride = 1000000;
+
+    /// <summary>
+    /// Picks the multiplier for the category id: the smallest power of ten that still fits every
+    /// channel number in the list, so no category can spill into the next one's range.
+    /// </summary>
+    /// <param name="channels">Channels about to be numbered.</param>
+    /// <returns>The stride to pass to <see cref="Resolve"/>.</returns>
+    internal static int ComputeStride(IEnumerable<LiveStreamInfo> channels)
+    {
+        int highest = 0;
+        foreach (var channel in channels)
+        {
+            if (channel.Num > highest)
+            {
+                highest = channel.Num;
+            }
+        }
+
+        int stride = MinimumStride;
+        while (stride <= highest && stride < MaximumStride)
+        {
+            stride *= 10;
+        }
+
+        return stride;
+    }
+
+    /// <summary>
+    /// Returns the number to publish for a channel.
+    /// </summary>
+    /// <param name="channel">The channel.</param>
+    /// <param name="stride">Stride from <see cref="ComputeStride"/>.</param>
+    /// <param name="byCategory">False returns the provider's own number unchanged.</param>
+    /// <returns>The channel number.</returns>
+    internal static int Resolve(LiveStreamInfo channel, int stride, bool byCategory)
+    {
+        if (!byCategory || channel.CategoryId is not int categoryId || categoryId < 0)
+        {
+            // A channel the provider files under no category has nothing to group by, so it keeps
+            // its own number and sorts among the low numbers.
+            return channel.Num;
+        }
+
+        long composite = ((long)categoryId * stride) + channel.Num;
+
+        // Providers have been seen with category ids in the thousands; combined with a widened
+        // stride that can leave the int range. Falling back to the raw number keeps such a channel
+        // working, at the cost of it sorting outside its category.
+        return composite > int.MaxValue ? channel.Num : (int)composite;
+    }
+}

--- a/Jellyfin.Xtream.Library/Service/LiveTvService.cs
+++ b/Jellyfin.Xtream.Library/Service/LiveTvService.cs
@@ -844,7 +844,10 @@ public class LiveTvService : IDisposable
             ? channels.Where(c => c.TvArchive && c.TvArchiveDuration > 0).ToList()
             : channels;
 
-        foreach (var channel in filteredChannels.OrderBy(c => c.Num))
+        int stride = ChannelNumbering.ComputeStride(filteredChannels);
+        bool numberByCategory = config.LiveTvNumberByCategory;
+
+        foreach (var channel in filteredChannels.OrderBy(c => ChannelNumbering.Resolve(c, stride, numberByCategory)))
         {
             var cleanName = ChannelNameCleaner.CleanChannelName(
                 channel.Name,
@@ -857,7 +860,7 @@ public class LiveTvService : IDisposable
             extinf.Append("#EXTINF:-1");
             extinf.Append(CultureInfo.InvariantCulture, $" tvg-id=\"{EscapeAttribute(epgId)}\"");
             extinf.Append(CultureInfo.InvariantCulture, $" tvg-name=\"{EscapeAttribute(cleanName)}\"");
-            extinf.Append(CultureInfo.InvariantCulture, $" tvg-chno=\"{channel.Num}\"");
+            extinf.Append(CultureInfo.InvariantCulture, $" tvg-chno=\"{ChannelNumbering.Resolve(channel, stride, numberByCategory)}\"");
 
             var logoUrl = ChannelLogoResolver.ResolveDisplayUrl(channel.StreamIcon, channel.StreamId, baseUrl);
             if (!string.IsNullOrEmpty(logoUrl))
@@ -978,7 +981,10 @@ public class LiveTvService : IDisposable
         sb.AppendLine("<tv generator-info-name=\"Jellyfin Xtream Library\">");
 
         // Channel definitions
-        foreach (var channel in channels.OrderBy(c => c.Num))
+        int epgStride = ChannelNumbering.ComputeStride(channels);
+        bool epgNumberByCategory = config.LiveTvNumberByCategory;
+
+        foreach (var channel in channels.OrderBy(c => ChannelNumbering.Resolve(c, epgStride, epgNumberByCategory)))
         {
             var cleanName = ChannelNameCleaner.CleanChannelName(
                 channel.Name,

--- a/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
+++ b/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
@@ -57,6 +57,7 @@ public class XtreamTunerHost : ITunerHost
     private volatile Dictionary<string, StreamStatsInfo> _streamStats = new();
     private List<ChannelInfo>? _cachedChannels;
     private DateTime _cacheTime = DateTime.MinValue;
+    private bool _cachedNumberByCategory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XtreamTunerHost"/> class.
@@ -94,7 +95,12 @@ public class XtreamTunerHost : ITunerHost
         }
 
         // Return cached channels if available and not expired
-        if (enableCache && _cachedChannels != null && DateTime.UtcNow - _cacheTime < CacheDuration)
+        // The numbering flag is part of the cache identity: flipping it changes every number, and
+        // serving the previous list would leave the numbers and the resolver map disagreeing.
+        if (enableCache
+            && _cachedChannels != null
+            && _cachedNumberByCategory == config.LiveTvNumberByCategory
+            && DateTime.UtcNow - _cacheTime < CacheDuration)
         {
             _logger.LogDebug("Returning cached channel list ({Count} channels)", _cachedChannels.Count);
             return _cachedChannels;
@@ -105,6 +111,7 @@ public class XtreamTunerHost : ITunerHost
         var channels = await _liveTvService.GetFilteredChannelsAsync(cancellationToken).ConfigureAwait(false);
         var categoryNames = await _liveTvService.GetCategoryNameMapAsync(cancellationToken).ConfigureAwait(false);
 
+        int stride = ChannelNumbering.ComputeStride(channels);
         var newMap = new Dictionary<string, string>(channels.Count);
         var newStats = new Dictionary<string, StreamStatsInfo>(channels.Count);
         int statsCount = 0;
@@ -112,7 +119,9 @@ public class XtreamTunerHost : ITunerHost
         var result = new List<ChannelInfo>(channels.Count);
         foreach (var channel in channels)
         {
-            var channelNumber = channel.Num.ToString(CultureInfo.InvariantCulture);
+            var channelNumber = ChannelNumbering
+                .Resolve(channel, stride, config.LiveTvNumberByCategory)
+                .ToString(CultureInfo.InvariantCulture);
             var channelId = BuildChannelId(channel.ProviderIndex, channel.StreamId);
 
             if (!newMap.TryAdd(channelNumber, channelId))
@@ -155,6 +164,7 @@ public class XtreamTunerHost : ITunerHost
         _streamStats = newStats;
         _cachedChannels = result;
         _cacheTime = DateTime.UtcNow;
+        _cachedNumberByCategory = config.LiveTvNumberByCategory;
         _logger.LogInformation("Channel list cached with {Count} channels ({StatsCount} with stream stats)", result.Count, statsCount);
 
         return result;


### PR DESCRIPTION
## What was asked

Sort channels by category and then by channel number, instead of all the number-1 channels clustering together across categories.

## What was actually wrong

Providers number channels from 1 inside every category, and `XtreamTunerHost` publishes that raw number as `ChannelInfo.Number` (the M3U path does the same with `tvg-chno`). Jellyfin sorts the guide on it, hence the interleaving.

There is a second, quieter consequence. That number is the key `_channelNumberToChannelId` is built on, and Jellyfin remaps tuner channel ids to `hdhr_<number>`, which the plugin resolves back to a stream. Two channels sharing a number therefore leave one of them unreachable, or tuning the wrong stream. The log already said so: `Duplicate channel number {Num} - channel {Old} overwritten by {New}`. So this was filed as a sorting request but it was covering a correctness bug.

## The change

An opt-in setting, `Group channel numbers by category`, off by default. When on, the published number becomes `categoryId * stride + channelNumber`, applied consistently to the tuner host, the M3U emitter and the XMLTV channel order.

On the two things raised in the thread:

- **Overflow.** The stride is the smallest power of ten that still fits every channel number in the list, so a provider that numbers past 999 widens it rather than letting one category spill into the next. A composite that would still leave the int range falls back to the raw number instead of wrapping, which would tune the wrong channel. With category ids in the 8000s, as reported, a number like 8123012 sits comfortably inside an int.
- **Category id rather than a running index.** An index would renumber everything whenever the provider adds a category. The id keeps numbers stable.

The flag is part of the tuner cache identity, otherwise flipping it would serve a cached list whose numbers disagree with the resolver map. Jellyfin still holds the old numbers in its own database until the guide is refreshed, which the setting description says.

## Tests

`ChannelNumberingTests` covers the stride, the composite, both fallbacks and the collision case; two `XtreamTunerHostTests` cover the flag end to end, including that the default path is untouched. 677 tests pass.

Requested by dulfer. Closes #86.