### PR TITLE
fix(dispatcharr): give Dispatcharr its own URL (#83)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Client/DispatcharrClientTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Client/DispatcharrClientTests.cs
@@ -253,6 +253,37 @@ public class DispatcharrClientTests : IDisposable
     /// <summary>
     /// HTTP handler that delegates to a func for full control.
     /// </summary>
+    // GitHub #83. The token base used to be re-derived from the request URL as scheme://authority,
+    // which silently dropped a path. Dispatcharr behind a reverse proxy on a subpath then had its
+    // data calls routed correctly and its login sent one level too high, where there is no route.
+    [Fact]
+    public async Task TokenRequest_KeepsThePathOfTheBaseUrlItWasGiven()
+    {
+        var requested = new List<string>();
+        var handler = new FuncHttpMessageHandler((request, ct) =>
+        {
+            var url = request.RequestUri!.ToString();
+            requested.Add(url);
+
+            var json = url.Contains("/api/accounts/token/", StringComparison.Ordinal)
+                ? JsonConvert.SerializeObject(new { access = "test-token", refresh = "refresh-token" })
+                : JsonConvert.SerializeObject(new { id = 42, uuid = "abc-123", name = "Test" });
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var client = new DispatcharrClient(new HttpClient(handler), _mockLogger.Object);
+        client.Configure("admin", "secret");
+
+        await client.GetMovieDetailAsync("https://proxy.example.com/dispatcharr", 42, CancellationToken.None);
+
+        requested.Should().Contain("https://proxy.example.com/dispatcharr/api/accounts/token/");
+        requested.Should().NotContain(u => u.Equals("https://proxy.example.com/api/accounts/token/", StringComparison.Ordinal));
+    }
+
     private class FuncHttpMessageHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;

--- a/Jellyfin.Xtream.Library.Tests/DispatcharrBaseUrlTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/DispatcharrBaseUrlTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #83. Dispatcharr mode had no URL of its own, so the JWT login was posted to the Xtream
+// endpoint. On the reporter's setup that endpoint has no /api/accounts/token/ route and answers
+// 404, which surfaced as "Dispatcharr JWT login failed with status NotFound".
+
+using FluentAssertions;
+using Jellyfin.Xtream.Library;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests;
+
+public class DispatcharrBaseUrlTests
+{
+    [Fact]
+    public void EmptyDispatcharrUrl_FallsBackToTheXtreamUrl()
+    {
+        // Every install that worked before this field existed had them on one host, so an empty
+        // value has to keep meaning exactly that.
+        var provider = new ProviderConfig { BaseUrl = "http://same-host:8901" };
+
+        provider.EffectiveDispatcharrBaseUrl.Should().Be("http://same-host:8901");
+    }
+
+    [Fact]
+    public void ADedicatedUrl_IsUsedInsteadOfTheXtreamOne()
+    {
+        var provider = new ProviderConfig
+        {
+            BaseUrl = "http://xtream-host:8901",
+            DispatcharrBaseUrl = "http://dispatcharr-host:9191",
+        };
+
+        provider.EffectiveDispatcharrBaseUrl.Should().Be("http://dispatcharr-host:9191");
+    }
+
+    [Theory]
+    [InlineData("http://dispatcharr:9191/", "http://dispatcharr:9191")]
+    [InlineData("  http://dispatcharr:9191  ", "http://dispatcharr:9191")]
+    [InlineData("http://proxy/dispatcharr/", "http://proxy/dispatcharr")]
+    public void TheUrlIsNormalised_BecauseEveryCallerAppendsApiPaths(string configured, string expected)
+    {
+        new ProviderConfig { BaseUrl = "http://xtream:8901", DispatcharrBaseUrl = configured }
+            .EffectiveDispatcharrBaseUrl.Should().Be(expected);
+    }
+
+    [Fact]
+    public void APathIsKept_ForDispatcharrBehindAReverseProxy()
+    {
+        new ProviderConfig { BaseUrl = "http://xtream:8901", DispatcharrBaseUrl = "https://proxy/dispatcharr" }
+            .EffectiveDispatcharrBaseUrl.Should().Be("https://proxy/dispatcharr");
+    }
+
+    [Fact]
+    public void WhitespaceOnly_CountsAsUnset()
+    {
+        new ProviderConfig { BaseUrl = "http://xtream:8901", DispatcharrBaseUrl = "   " }
+            .EffectiveDispatcharrBaseUrl.Should().Be("http://xtream:8901");
+    }
+}

--- a/Jellyfin.Xtream.Library/Api/SyncController.cs
+++ b/Jellyfin.Xtream.Library/Api/SyncController.cs
@@ -312,7 +312,7 @@ public class SyncController : ControllerBase
         try
         {
             _dispatcharrClient.Configure(provider.DispatcharrApiUser, provider.DispatcharrApiPass);
-            var success = await _dispatcharrClient.TestConnectionAsync(provider.BaseUrl, cancellationToken).ConfigureAwait(false);
+            var success = await _dispatcharrClient.TestConnectionAsync(provider.EffectiveDispatcharrBaseUrl, cancellationToken).ConfigureAwait(false);
 
             if (success)
             {

--- a/Jellyfin.Xtream.Library/Client/DispatcharrClient.cs
+++ b/Jellyfin.Xtream.Library/Client/DispatcharrClient.cs
@@ -83,7 +83,7 @@ public class DispatcharrClient : IDispatcharrClient
     {
         try
         {
-            var json = await GetAuthenticatedAsync($"{baseUrl}/api/vod/movies/{movieId}/", cancellationToken).ConfigureAwait(false);
+            var json = await GetAuthenticatedAsync(baseUrl, $"{baseUrl}/api/vod/movies/{movieId}/", cancellationToken).ConfigureAwait(false);
             if (json == null)
             {
                 return null;
@@ -103,7 +103,7 @@ public class DispatcharrClient : IDispatcharrClient
     {
         try
         {
-            var json = await GetAuthenticatedAsync($"{baseUrl}/api/vod/movies/{movieId}/providers/", cancellationToken).ConfigureAwait(false);
+            var json = await GetAuthenticatedAsync(baseUrl, $"{baseUrl}/api/vod/movies/{movieId}/providers/", cancellationToken).ConfigureAwait(false);
             if (json == null)
             {
                 return new List<DispatcharrMovieProvider>();
@@ -133,12 +133,11 @@ public class DispatcharrClient : IDispatcharrClient
         }
     }
 
-    private async Task<string?> GetAuthenticatedAsync(string url, CancellationToken cancellationToken)
+    private async Task<string?> GetAuthenticatedAsync(string baseUrl, string url, CancellationToken cancellationToken)
     {
-        // Extract base URL from the full URL for token acquisition
-        var uri = new Uri(url);
-        var baseUrl = $"{uri.Scheme}://{uri.Authority}";
-
+        // The base URL is passed in rather than derived from the request URL. Deriving it as
+        // scheme://authority dropped any path, so a Dispatcharr behind a reverse proxy on a subpath
+        // had its data calls sent to the right place and its login sent to the wrong one (#83).
         await EnsureTokenAsync(baseUrl, cancellationToken).ConfigureAwait(false);
 
         if (_accessToken == null)

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -633,6 +633,16 @@
                                 </div>
                                 <div id="dispatcharrSettings" style="display: none;">
                                     <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="txtDispatcharrBaseUrl">Dispatcharr URL</label>
+                                        <input is="emby-input" type="text" id="txtDispatcharrBaseUrl" name="DispatcharrBaseUrl"
+                                            placeholder="http://dispatcharr-host:9191" />
+                                        <div class="fieldDescription">
+                                            Leave empty if Dispatcharr answers on the same address as the Xtream URL above.
+                                            Fill this in when it runs on a different host, port or path, otherwise the login
+                                            is sent to the Xtream server and fails with "JWT login failed with status NotFound".
+                                        </div>
+                                    </div>
+                                    <div class="inputContainer">
                                         <label class="inputLabel inputLabelUnfocused" for="txtDispatcharrApiUser">API Username</label>
                                         <input is="emby-input" type="text" id="txtDispatcharrApiUser" name="DispatcharrApiUser" />
                                         <div class="fieldDescription">

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -160,6 +160,7 @@ const XtreamLibraryConfig = {
         document.getElementById('chkEnableProactiveMediaInfo').checked = p.EnableProactiveMediaInfo || false;
 
         document.getElementById('chkEnableDispatcharrMode').checked = p.EnableDispatcharrMode || false;
+        document.getElementById('txtDispatcharrBaseUrl').value = p.DispatcharrBaseUrl || '';
         document.getElementById('txtDispatcharrApiUser').value = p.DispatcharrApiUser || '';
         document.getElementById('txtDispatcharrApiPass').value = p.DispatcharrApiPass || '';
         self.updateDispatcharrVisibility();
@@ -262,6 +263,7 @@ const XtreamLibraryConfig = {
         p.EnableProactiveMediaInfo = document.getElementById('chkEnableProactiveMediaInfo').checked;
 
         p.EnableDispatcharrMode = document.getElementById('chkEnableDispatcharrMode').checked;
+        p.DispatcharrBaseUrl = document.getElementById('txtDispatcharrBaseUrl').value.trim().replace(/\/$/, '');
         p.DispatcharrApiUser = document.getElementById('txtDispatcharrApiUser').value.trim();
         p.DispatcharrApiPass = document.getElementById('txtDispatcharrApiPass').value.trim();
     },

--- a/Jellyfin.Xtream.Library/Plugin.cs
+++ b/Jellyfin.Xtream.Library/Plugin.cs
@@ -128,6 +128,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             EnableProactiveMediaInfo = config.EnableProactiveMediaInfo,
             FallbackToYearlessLookup = config.FallbackToYearlessLookup,
             EnableDispatcharrMode = config.EnableDispatcharrMode,
+            DispatcharrBaseUrl = config.DispatcharrBaseUrl,
             DispatcharrApiUser = config.DispatcharrApiUser,
             DispatcharrApiPass = config.DispatcharrApiPass,
             EnableIncrementalSync = config.EnableIncrementalSync,
@@ -340,6 +341,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         target.EnableProactiveMediaInfo = source.EnableProactiveMediaInfo;
         target.FallbackToYearlessLookup = source.FallbackToYearlessLookup;
         target.EnableDispatcharrMode = source.EnableDispatcharrMode;
+        target.DispatcharrBaseUrl = source.DispatcharrBaseUrl;
         target.DispatcharrApiUser = source.DispatcharrApiUser;
         target.DispatcharrApiPass = source.DispatcharrApiPass;
         target.EnableIncrementalSync = source.EnableIncrementalSync;

--- a/Jellyfin.Xtream.Library/PluginConfiguration.cs
+++ b/Jellyfin.Xtream.Library/PluginConfiguration.cs
@@ -316,6 +316,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool EnableDispatcharrMode { get; set; }
 
     /// <summary>Gets or sets the legacy Dispatcharr API user. Migrated to Providers[0].</summary>
+    public string DispatcharrBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Dispatcharr REST API username.
+    /// </summary>
     public string DispatcharrApiUser { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the legacy Dispatcharr API password. Migrated to Providers[0].</summary>

--- a/Jellyfin.Xtream.Library/ProviderConfig.cs
+++ b/Jellyfin.Xtream.Library/ProviderConfig.cs
@@ -208,6 +208,30 @@ public class ProviderConfig
     public bool EnableDispatcharrMode { get; set; }
 
     /// <summary>
+    /// Gets or sets the base URL of the Dispatcharr instance, protocol and port included.
+    /// <para>
+    /// Empty means "the same host as <see cref="BaseUrl"/>", which is what every install did before
+    /// this field existed. Dispatcharr on a different host or port was simply broken: the JWT login
+    /// was posted to the Xtream endpoint, which has no such route and answers 404 (GitHub #83).
+    /// </para>
+    /// </summary>
+    public string DispatcharrBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the URL Dispatcharr calls actually go to: the dedicated one when set, otherwise the
+    /// Xtream base URL. Any trailing slash is removed, because every caller appends "/api/...".
+    /// A path is kept, so Dispatcharr behind a reverse proxy on a subpath works.
+    /// </summary>
+    public string EffectiveDispatcharrBaseUrl
+    {
+        get
+        {
+            string configured = string.IsNullOrWhiteSpace(DispatcharrBaseUrl) ? BaseUrl : DispatcharrBaseUrl;
+            return (configured ?? string.Empty).Trim().TrimEnd('/');
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the Dispatcharr REST API username.
     /// </summary>
     public string DispatcharrApiUser { get; set; } = string.Empty;

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -1822,10 +1822,10 @@ public partial class StrmSyncService
                     {
                         try
                         {
-                            var detail = await _dispatcharrClient.GetMovieDetailAsync(connectionInfo.BaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
+                            var detail = await _dispatcharrClient.GetMovieDetailAsync(provider.EffectiveDispatcharrBaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
                             if (detail != null && !string.IsNullOrEmpty(detail.Uuid))
                             {
-                                var providers = await _dispatcharrClient.GetMovieProvidersAsync(connectionInfo.BaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
+                                var providers = await _dispatcharrClient.GetMovieProvidersAsync(provider.EffectiveDispatcharrBaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
                                 if (providers.Count > 1)
                                 {
                                     // Deduplicate by stream_id


### PR DESCRIPTION
## The bug

`Dispatcharr JWT login failed with status NotFound`, while the same `POST /api/accounts/token/` returns a valid token by hand.

The cause is architectural rather than a wrong path. Dispatcharr mode has no URL of its own: `TestConnectionAsync`, `GetMovieDetailAsync` and `GetMovieProvidersAsync` are all handed `provider.BaseUrl`, which is the Xtream endpoint. If Dispatcharr answers on a different host or port, the login is posted to a server that has no such route, and 404 is exactly what you get. Anyone running both on one address, which is the common single-box setup, never saw it.

## The fix

A `DispatcharrBaseUrl` field on the provider config. Empty means "the same address as the Xtream URL", which is what every install did before this field existed, so nothing changes for anyone who is not affected.

While in there: `GetAuthenticatedAsync` used to re-derive the token base from the request URL as `scheme://authority`, which drops any path. Dispatcharr behind a reverse proxy on a subpath (`https://proxy/dispatcharr`) therefore had its data calls routed correctly and its login sent one level too high, failing the same way for a different reason. The base URL is now passed in rather than reconstructed, and the resolved URL keeps its path while losing any trailing slash.

## Note for the reporter

@jght2 you were asked whether Dispatcharr runs on the same host as the Xtream provider, and that answer never came. This change makes the question moot: if they are on one address nothing changes for you, and if they are not, fill in the new **Dispatcharr URL** field. If the login still fails after that, the next thing to check is whether Dispatcharr sits on a subpath, which the second half of this change covers.

## Tests

`DispatcharrBaseUrlTests` covers the fallback, the override, normalisation and the reverse-proxy path; one client test asserts the token request keeps the configured path instead of being hoisted to the host root. 673 tests pass.

Reported by jght2. Fixes #83.