### PR TITLE
feat(sync): record what each stream resolved to (#88, part 1 of 2)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Service/ItemIdentityTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/ItemIdentityTests.cs
@@ -1,0 +1,165 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #88 groundwork. Grouping items by TMDB id needs to know, per stream, which folder it went
+// to and how trustworthy the id is. Only a provider-supplied id may be merged on: a name lookup can
+// give a live-action film and its animated remake the same id, which is the one case that must not
+// merge.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Service;
+using Jellyfin.Xtream.Library.Service.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class ItemIdentityTests
+{
+    private static readonly Dictionary<string, int> NoOverrides = [];
+
+    [Theory]
+    [InlineData("Some Movie (2024) [tmdbid-1234]", 1234)]
+    [InlineData("Some Movie (2024) [TMDBID-99]", 99)]
+    [InlineData("Weird [tmdbid-1] Name [tmdbid-2]", 1)]
+    public void TmdbId_IsReadBackOutOfAFolderName(string folderName, int expected)
+    {
+        FolderIdentity.TryParseTmdbId(folderName, out int id).Should().BeTrue();
+        id.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Some Movie (2024)")]
+    [InlineData("Some Movie [tmdbid-]")]
+    [InlineData("Some Movie [tvdbid-1234]")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void NoTmdbIdInTheName_IsNotAnId(string? folderName)
+    {
+        FolderIdentity.TryParseTmdbId(folderName, out int id).Should().BeFalse();
+        id.Should().Be(0);
+    }
+
+    [Fact]
+    public void TvdbId_IsReadBackToo_BecauseSeriesFoldersPreferIt()
+    {
+        FolderIdentity.TryParseTvdbId("Some Show [tvdbid-4321]", out int id).Should().BeTrue();
+        id.Should().Be(4321);
+    }
+
+    [Fact]
+    public void AnIdTooLargeForAnInt_IsRefusedRatherThanWrapped()
+    {
+        FolderIdentity.TryParseTmdbId("Some Movie [tmdbid-99999999999]", out int id).Should().BeFalse();
+        id.Should().Be(0);
+    }
+
+    [Fact]
+    public void AnOverrideOutranksEverything()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-1]",
+            "Movie (2024)",
+            fromExistingFolder: false,
+            new Dictionary<string, int> { ["Movie (2024)"] = 1 },
+            providerTmdbId: 2,
+            autoLookupTmdbId: 3);
+
+        identity.TmdbId.Should().Be(1);
+        identity.Source.Should().Be(ItemIdSource.Override);
+    }
+
+    [Fact]
+    public void AProviderIdOutranksALookup()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-2]", "Movie (2024)", fromExistingFolder: false, NoOverrides, 2, 3);
+
+        identity.TmdbId.Should().Be(2);
+        identity.Source.Should().Be(ItemIdSource.Provider);
+    }
+
+    [Fact]
+    public void ALookupIsRecordedAsSuch_SoGroupingCanRefuseIt()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-3]", "Movie (2024)", fromExistingFolder: false, NoOverrides, null, 3);
+
+        identity.TmdbId.Should().Be(3);
+        identity.Source.Should().Be(ItemIdSource.Lookup);
+    }
+
+    [Fact]
+    public void NoIdAtAll_IsRecordedAsNone()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024)", "Movie (2024)", fromExistingFolder: false, NoOverrides, null, null);
+
+        identity.TmdbId.Should().BeNull();
+        identity.Source.Should().Be(ItemIdSource.None);
+    }
+
+    [Fact]
+    public void AnIdReadOffDisk_IsUnprovenEvenThoughItIsKnown()
+    {
+        // The folder is all that is left for a library synced before the snapshot carried this, and
+        // it does not say whether the provider gave the id or a lookup guessed it.
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-1234]", "Movie (2024)", fromExistingFolder: true, NoOverrides, null, null);
+
+        identity.TmdbId.Should().Be(1234);
+        identity.Source.Should().Be(ItemIdSource.Unknown);
+        identity.FolderName.Should().Be("Movie (2024) [tmdbid-1234]");
+    }
+
+    [Fact]
+    public void ASeriesKeepsItsTvdbIdSeparateFromTmdb()
+    {
+        var identity = StrmSyncService.BuildSeriesIdentity(
+            "Show [tvdbid-77]", "Show", NoOverrides, providerTmdbId: null, autoLookupTvdbId: 77);
+
+        identity.TvdbId.Should().Be(77);
+        identity.TmdbId.Should().BeNull();
+        identity.Source.Should().Be(ItemIdSource.Lookup);
+    }
+
+    [Fact]
+    public void TheNewFieldsSurviveTheSnapshotRoundTrip()
+    {
+        var snapshot = new ContentSnapshot();
+        snapshot.Movies[100] = new MovieSnapshot
+        {
+            StreamId = 100,
+            Name = "Movie",
+            FolderName = "Movie (2024) [tmdbid-1234]",
+            TmdbId = 1234,
+            TmdbIdSource = ItemIdSource.Provider,
+        };
+
+        var restored = JsonConvert.DeserializeObject<ContentSnapshot>(JsonConvert.SerializeObject(snapshot))!;
+
+        restored.Movies[100].FolderName.Should().Be("Movie (2024) [tmdbid-1234]");
+        restored.Movies[100].TmdbId.Should().Be(1234);
+        restored.Movies[100].TmdbIdSource.Should().Be(ItemIdSource.Provider);
+    }
+
+    [Fact]
+    public void ASnapshotWrittenBeforeTheseFieldsExisted_StillLoads()
+    {
+        // Upgrade path: the fields are simply absent from an older snapshot file.
+        const string Old = """
+            {"Movies":{"100":{"StreamId":100,"Name":"Movie","Checksum":"abc"}},"Series":{}}
+            """;
+
+        var restored = JsonConvert.DeserializeObject<ContentSnapshot>(Old)!;
+
+        restored.Movies[100].FolderName.Should().BeEmpty();
+        restored.Movies[100].TmdbId.Should().BeNull();
+        restored.Movies[100].TmdbIdSource.Should().Be(ItemIdSource.None);
+    }
+}

--- a/Jellyfin.Xtream.Library/Service/FolderIdentity.cs
+++ b/Jellyfin.Xtream.Library/Service/FolderIdentity.cs
@@ -1,0 +1,64 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.RegularExpressions;
+
+namespace Jellyfin.Xtream.Library.Service;
+
+/// <summary>
+/// Reads the metadata ids back out of a folder name.
+/// <para>
+/// Folder names are the only record of an item's identity for a library synced before the snapshot
+/// started carrying it, so this is what backfills those items on the next sync (GitHub #88).
+/// </para>
+/// </summary>
+public static partial class FolderIdentity
+{
+    /// <summary>
+    /// Reads the TMDB id out of a folder name such as "Some Movie (2024) [tmdbid-1234]".
+    /// </summary>
+    /// <param name="folderName">Folder name to read.</param>
+    /// <param name="tmdbId">The id, when the name carries one.</param>
+    /// <returns>True when an id was found.</returns>
+    public static bool TryParseTmdbId(string? folderName, out int tmdbId)
+        => TryParse(TmdbIdPattern(), folderName, out tmdbId);
+
+    /// <summary>
+    /// Reads the TVDB id out of a folder name such as "Some Show [tvdbid-1234]".
+    /// </summary>
+    /// <param name="folderName">Folder name to read.</param>
+    /// <param name="tvdbId">The id, when the name carries one.</param>
+    /// <returns>True when an id was found.</returns>
+    public static bool TryParseTvdbId(string? folderName, out int tvdbId)
+        => TryParse(TvdbIdPattern(), folderName, out tvdbId);
+
+    private static bool TryParse(Regex pattern, string? folderName, out int id)
+    {
+        id = 0;
+        if (string.IsNullOrEmpty(folderName))
+        {
+            return false;
+        }
+
+        var match = pattern.Match(folderName);
+        return match.Success && int.TryParse(match.Groups[1].ValueSpan, out id);
+    }
+
+    [GeneratedRegex(@"\[tmdbid-(\d+)\]", RegexOptions.IgnoreCase)]
+    private static partial Regex TmdbIdPattern();
+
+    [GeneratedRegex(@"\[tvdbid-(\d+)\]", RegexOptions.IgnoreCase)]
+    private static partial Regex TvdbIdPattern();
+}

--- a/Jellyfin.Xtream.Library/Service/Models/ContentSnapshot.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/ContentSnapshot.cs
@@ -87,6 +87,23 @@ public class MovieSnapshot
     /// Gets or sets the MD5 checksum of key fields for change detection.
     /// </summary>
     public string Checksum { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the folder this stream was written to, without the library path.
+    /// Empty in a snapshot written before this was recorded (GitHub #88).
+    /// </summary>
+    public string FolderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the TMDB id the item resolved to, if any.
+    /// </summary>
+    public int? TmdbId { get; set; }
+
+    /// <summary>
+    /// Gets or sets where <see cref="TmdbId"/> came from. Only a provider-supplied id is safe to
+    /// merge two items on.
+    /// </summary>
+    public ItemIdSource TmdbIdSource { get; set; }
 }
 
 /// <summary>
@@ -128,6 +145,27 @@ public class SeriesSnapshot
     /// Gets or sets the MD5 checksum of key fields for change detection.
     /// </summary>
     public string Checksum { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the folder this series was written to, without the library path.
+    /// Empty in a snapshot written before this was recorded (GitHub #88).
+    /// </summary>
+    public string FolderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the TMDB id the series resolved to, if any.
+    /// </summary>
+    public int? TmdbId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TVDB id the series resolved to, if any. Series folders prefer TVDB.
+    /// </summary>
+    public int? TvdbId { get; set; }
+
+    /// <summary>
+    /// Gets or sets where the recorded id came from.
+    /// </summary>
+    public ItemIdSource IdSource { get; set; }
 }
 
 /// <summary>

--- a/Jellyfin.Xtream.Library/Service/Models/ItemIdentity.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/ItemIdentity.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Library.Service.Models;
+
+/// <summary>
+/// Where the metadata id recorded for an item came from. The distinction matters for grouping
+/// (GitHub #88): only an id the provider itself supplied is safe to merge two items on. An id a
+/// name lookup guessed can be wrong in exactly the way that hurts, for example a live-action film
+/// and its animated remake sharing a title.
+/// </summary>
+public enum ItemIdSource
+{
+    /// <summary>No id was resolved.</summary>
+    None = 0,
+
+    /// <summary>The provider returned the id in its own metadata.</summary>
+    Provider = 1,
+
+    /// <summary>A name-based lookup guessed the id.</summary>
+    Lookup = 2,
+
+    /// <summary>The user pinned the id in the folder overrides.</summary>
+    Override = 3,
+
+    /// <summary>
+    /// The id was read back off an existing folder name. Where it originally came from is not
+    /// recoverable from disk, so it is treated as unproven until a sync resolves the item again.
+    /// </summary>
+    Unknown = 4,
+}
+
+/// <summary>
+/// What one provider stream resolved to on disk during a sync.
+/// </summary>
+/// <param name="FolderName">Folder the item was written to, without the library path.</param>
+/// <param name="TmdbId">Resolved TMDB id, if any.</param>
+/// <param name="TvdbId">Resolved TVDB id, if any. Series only.</param>
+/// <param name="Source">Where <paramref name="TmdbId"/> or <paramref name="TvdbId"/> came from.</param>
+public sealed record ItemIdentity(string FolderName, int? TmdbId, int? TvdbId, ItemIdSource Source);

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -957,6 +957,12 @@ public partial class StrmSyncService
         var allCollectedSeries = new ConcurrentBag<Series>();
         var allSeriesInfoDict = new ConcurrentDictionary<int, SeriesStreamInfo>();
 
+        // What each stream resolved to on disk this run (GitHub #88). Recorded into the snapshot at
+        // the end so a later sync can group by metadata id without re-deriving it from folder names.
+        // Nothing reads it yet.
+        var movieIdentities = new ConcurrentDictionary<int, ItemIdentity>();
+        var seriesIdentities = new ConcurrentDictionary<int, ItemIdentity>();
+
         // Ensure base directories exist
         string moviesPath = Path.Combine(provider.LibraryPath, "Movies");
         string seriesPath = Path.Combine(provider.LibraryPath, "Series");
@@ -1002,6 +1008,7 @@ public partial class StrmSyncService
                             result,
                             previousSnapshot,
                             allCollectedMovies,
+                            movieIdentities,
                             cancellationToken).ConfigureAwait(false);
                     },
                     cancellationToken));
@@ -1023,6 +1030,7 @@ public partial class StrmSyncService
                             hintSnapshot,
                             allCollectedSeries,
                             allSeriesInfoDict,
+                            seriesIdentities,
                             cancellationToken).ConfigureAwait(false);
                     },
                     cancellationToken));
@@ -1044,6 +1052,7 @@ public partial class StrmSyncService
                     result,
                     previousSnapshot,
                     allCollectedMovies,
+                    movieIdentities,
                     cancellationToken).ConfigureAwait(false);
             }
 
@@ -1060,6 +1069,7 @@ public partial class StrmSyncService
                     hintSnapshot,
                     allCollectedSeries,
                     allSeriesInfoDict,
+                    seriesIdentities,
                     cancellationToken).ConfigureAwait(false);
             }
         }
@@ -1232,7 +1242,7 @@ public partial class StrmSyncService
         if (provider.EnableIncrementalSync && !cancellationToken.IsCancellationRequested)
         {
             CurrentProgress.Phase = "Saving snapshot";
-            await SaveSnapshotAsync(provider, providerKey, allCollectedMovies, allCollectedSeries, allSeriesInfoDict, result.FailedItems, cancellationToken).ConfigureAwait(false);
+            await SaveSnapshotAsync(provider, providerKey, allCollectedMovies, allCollectedSeries, allSeriesInfoDict, movieIdentities, seriesIdentities, result.FailedItems, cancellationToken).ConfigureAwait(false);
         }
 
         result.WasIncrementalSync = isIncrementalSync;
@@ -1406,6 +1416,7 @@ public partial class StrmSyncService
         SyncResult result,
         ContentSnapshot? previousSnapshot,
         ConcurrentBag<StreamInfo> allCollectedMovies,
+        ConcurrentDictionary<int, ItemIdentity> movieIdentities,
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
@@ -1975,6 +1986,14 @@ public partial class StrmSyncService
                         folderName = BuildMovieFolderName(movieName, year, tmdbOverrides, providerTmdbId, autoLookupTmdbId);
                     }
 
+                    movieIdentities[stream.StreamId] = BuildMovieIdentity(
+                        folderName,
+                        baseName,
+                        existingFolderName != null,
+                        tmdbOverrides,
+                        providerTmdbId,
+                        autoLookupTmdbId);
+
                     // Build STRM URLs and filenames — Dispatcharr multi-stream or standard single-stream
                     var strmEntries = new List<(string StreamUrl, string StrmFileName)>();
                     if (enableDispatcharrMode &&
@@ -2241,6 +2260,7 @@ public partial class StrmSyncService
         ContentSnapshot? hintSnapshot,
         ConcurrentBag<Series> allCollectedSeries,
         ConcurrentDictionary<int, SeriesStreamInfo> allSeriesInfoDict,
+        ConcurrentDictionary<int, ItemIdentity> seriesIdentities,
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
@@ -2847,6 +2867,13 @@ public partial class StrmSyncService
                     }
 
                     string seriesFolderName = BuildSeriesFolderName(seriesName, year, tvdbOverrides, providerTmdbId, autoLookupTvdbId);
+
+                    seriesIdentities[series.SeriesId] = BuildSeriesIdentity(
+                        seriesFolderName,
+                        baseName,
+                        tvdbOverrides,
+                        providerTmdbId,
+                        autoLookupTvdbId);
 
                     // Determine target folders based on category mappings
                     var targetFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -3750,6 +3777,85 @@ public partial class StrmSyncService
     }
 
     /// <summary>
+    /// Records what a movie stream resolved to, and how trustworthy the id behind it is.
+    /// </summary>
+    /// <param name="folderName">Folder the movie was written to.</param>
+    /// <param name="baseName">Title and year, the key the overrides are stored under.</param>
+    /// <param name="fromExistingFolder">True when the name was reused from a folder already on disk.</param>
+    /// <param name="overrides">Manual TMDB overrides.</param>
+    /// <param name="providerTmdbId">TMDB id the provider itself returned.</param>
+    /// <param name="autoLookupTmdbId">TMDB id a name lookup guessed.</param>
+    /// <returns>The identity to record for this stream.</returns>
+    internal static ItemIdentity BuildMovieIdentity(
+        string folderName,
+        string baseName,
+        bool fromExistingFolder,
+        Dictionary<string, int> overrides,
+        int? providerTmdbId,
+        int? autoLookupTmdbId)
+    {
+        if (fromExistingFolder)
+        {
+            // The folder is the only record left, and it does not say where its id came from.
+            // That matters: grouping may only merge ids the provider supplied, never ones a name
+            // lookup guessed, so this stays unproven until a sync resolves the item again.
+            int? diskTmdbId = FolderIdentity.TryParseTmdbId(folderName, out int parsedTmdbId) ? parsedTmdbId : null;
+            return new ItemIdentity(folderName, diskTmdbId, null, ItemIdSource.Unknown);
+        }
+
+        if (overrides.TryGetValue(baseName, out int overrideTmdbId))
+        {
+            return new ItemIdentity(folderName, overrideTmdbId, null, ItemIdSource.Override);
+        }
+
+        if (providerTmdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, providerTmdbId, null, ItemIdSource.Provider);
+        }
+
+        if (autoLookupTmdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, autoLookupTmdbId, null, ItemIdSource.Lookup);
+        }
+
+        return new ItemIdentity(folderName, null, null, ItemIdSource.None);
+    }
+
+    /// <summary>
+    /// Records what a series resolved to. Series folders prefer TVDB, so both ids are kept.
+    /// </summary>
+    /// <param name="folderName">Folder the series was written to.</param>
+    /// <param name="baseName">Title and year, the key the overrides are stored under.</param>
+    /// <param name="overrides">Manual TVDB overrides.</param>
+    /// <param name="providerTmdbId">TMDB id the provider itself returned.</param>
+    /// <param name="autoLookupTvdbId">TVDB id a name lookup guessed.</param>
+    /// <returns>The identity to record for this series.</returns>
+    internal static ItemIdentity BuildSeriesIdentity(
+        string folderName,
+        string baseName,
+        Dictionary<string, int> overrides,
+        int? providerTmdbId,
+        int? autoLookupTvdbId)
+    {
+        if (overrides.TryGetValue(baseName, out int overrideTvdbId))
+        {
+            return new ItemIdentity(folderName, null, overrideTvdbId, ItemIdSource.Override);
+        }
+
+        if (providerTmdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, providerTmdbId, null, ItemIdSource.Provider);
+        }
+
+        if (autoLookupTvdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, null, autoLookupTvdbId, ItemIdSource.Lookup);
+        }
+
+        return new ItemIdentity(folderName, null, null, ItemIdSource.None);
+    }
+
+    /// <summary>
     /// Builds a movie folder name, optionally with TMDb ID suffix.
     /// </summary>
     /// <param name="sanitizedName">The sanitized movie name.</param>
@@ -4035,6 +4141,8 @@ public partial class StrmSyncService
         ConcurrentBag<StreamInfo> allMovies,
         ConcurrentBag<Series> allSeries,
         ConcurrentDictionary<int, SeriesStreamInfo> seriesInfoDict,
+        ConcurrentDictionary<int, ItemIdentity> movieIdentities,
+        ConcurrentDictionary<int, ItemIdentity> seriesIdentities,
         IReadOnlyList<FailedItem> failedItems,
         CancellationToken cancellationToken)
     {
@@ -4066,7 +4174,12 @@ public partial class StrmSyncService
                         ContainerExtension = movie.ContainerExtension,
                         CategoryId = movie.CategoryId ?? 0,
                         Added = movie.Added,
-                        Checksum = SnapshotService.CalculateChecksum(movie)
+                        Checksum = SnapshotService.CalculateChecksum(movie),
+                        FolderName = movieIdentities.TryGetValue(movie.StreamId, out var movieIdentity)
+                            ? movieIdentity.FolderName
+                            : string.Empty,
+                        TmdbId = movieIdentity?.TmdbId,
+                        TmdbIdSource = movieIdentity?.Source ?? ItemIdSource.None
                     };
                 }
             }
@@ -4091,7 +4204,13 @@ public partial class StrmSyncService
                         CategoryId = series.CategoryId ?? 0,
                         EpisodeCount = episodeCount,
                         LastModified = series.LastModified.GetValueOrDefault(),
-                        Checksum = SnapshotService.CalculateChecksum(series, episodeCount)
+                        Checksum = SnapshotService.CalculateChecksum(series, episodeCount),
+                        FolderName = seriesIdentities.TryGetValue(series.SeriesId, out var seriesIdentity)
+                            ? seriesIdentity.FolderName
+                            : string.Empty,
+                        TmdbId = seriesIdentity?.TmdbId,
+                        TvdbId = seriesIdentity?.TvdbId,
+                        IdSource = seriesIdentity?.Source ?? ItemIdSource.None
                     };
                 }
             }


### PR DESCRIPTION
Part 1 of 2 for #88. **Nothing on disk changes and nothing reads this yet**, which is the point: it can be merged and left to soak before the half that renames folders lands.

## Why this shape

The request was for two JSON databases holding `stream_id -> tmdb_id -> directory`. Most of that already exists. `ContentSnapshot` keeps a record per stream id (name, category, added, checksum), drives incremental sync, and is already written atomically, rotated and pruned every run. What it does not keep is what the item resolved to, so this adds three fields rather than a second store with its own lifecycle:

- `FolderName`: where the item was written
- `TmdbId`: the id it resolved to
- `TmdbIdSource`: where that id came from

Series records get the same, plus `TvdbId`, since series folders prefer TVDB.

## Why the source is tracked

This is the part that is not obvious, and it comes straight from the thread. Only an id the **provider** returned is safe to merge two items on. An id a name lookup guessed can be wrong in the one way that hurts: "The Lion King" the film and "The Lion King" the animation can be handed the same id, and merging those would be a data loss the user cannot undo.

So the source is one of `Provider`, `Lookup`, `Override`, `None`, or `Unknown`. `Unknown` is for an id read back off an existing folder name: a folder says `[tmdbid-1234]` but not who decided that, so it stays unproven until a sync resolves the item again. Grouping will be allowed to act on `Provider` and `Override` only.

## Backfill

`FolderIdentity` reads the ids back out of folder names, which is how items the sync skips still get a record. Snapshots written before these fields existed load unchanged with the fields empty; there is no migration step and no first-run scan.

## Tests

`ItemIdentityTests` covers the folder-name parsing including the malformed and out-of-range cases, the source precedence, the read-off-disk case staying `Unknown`, and both the round trip and the old-file-loads case. 683 tests pass.

## What part 2 will do

The opt-in grouping itself: merging items that share a provider-supplied id into one folder, plus the anti-collision for same-name different-id items. That one renames folders on disk, so it wants its own review and its own release warning.

Requested by andreadegiovine. Part of #88.
