### PR TITLE
feat(sync): group movies sharing a TMDB id (#88, part 2 of 2)

### DIFF
--- a/Jellyfin.Xtream.Library.Tests/Api/SyncControllerTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Api/SyncControllerTests.cs
@@ -30,6 +30,9 @@ using Xunit;
 
 namespace Jellyfin.Xtream.Library.Tests.Api;
 
+// Constructs a Plugin, so it has to serialise with the other classes that publish the singleton;
+// without this it races them and Plugin.Instance can vanish mid-test.
+[Collection("PluginSingletonTests")]
 public class SyncControllerTests
 {
     private readonly Mock<IXtreamClient> _mockClient;
@@ -276,7 +279,7 @@ public class SyncControllerTests
                 mockDispatcharrClient.Object,
                 _mockMetadataLookup.Object,
                 snapshotService,
-                appPathsMock.Object,
+                    appPathsMock.Object,
                 _mockControllerLogger.Object);
 
             // Act

--- a/Jellyfin.Xtream.Library.Tests/Client/DispatcharrClientTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Client/DispatcharrClientTests.cs
@@ -253,6 +253,37 @@ public class DispatcharrClientTests : IDisposable
     /// <summary>
     /// HTTP handler that delegates to a func for full control.
     /// </summary>
+    // GitHub #83. The token base used to be re-derived from the request URL as scheme://authority,
+    // which silently dropped a path. Dispatcharr behind a reverse proxy on a subpath then had its
+    // data calls routed correctly and its login sent one level too high, where there is no route.
+    [Fact]
+    public async Task TokenRequest_KeepsThePathOfTheBaseUrlItWasGiven()
+    {
+        var requested = new List<string>();
+        var handler = new FuncHttpMessageHandler((request, ct) =>
+        {
+            var url = request.RequestUri!.ToString();
+            requested.Add(url);
+
+            var json = url.Contains("/api/accounts/token/", StringComparison.Ordinal)
+                ? JsonConvert.SerializeObject(new { access = "test-token", refresh = "refresh-token" })
+                : JsonConvert.SerializeObject(new { id = 42, uuid = "abc-123", name = "Test" });
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var client = new DispatcharrClient(new HttpClient(handler), _mockLogger.Object);
+        client.Configure("admin", "secret");
+
+        await client.GetMovieDetailAsync("https://proxy.example.com/dispatcharr", 42, CancellationToken.None);
+
+        requested.Should().Contain("https://proxy.example.com/dispatcharr/api/accounts/token/");
+        requested.Should().NotContain(u => u.Equals("https://proxy.example.com/api/accounts/token/", StringComparison.Ordinal));
+    }
+
     private class FuncHttpMessageHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;

--- a/Jellyfin.Xtream.Library.Tests/DispatcharrBaseUrlTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/DispatcharrBaseUrlTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #83. Dispatcharr mode had no URL of its own, so the JWT login was posted to the Xtream
+// endpoint. On the reporter's setup that endpoint has no /api/accounts/token/ route and answers
+// 404, which surfaced as "Dispatcharr JWT login failed with status NotFound".
+
+using FluentAssertions;
+using Jellyfin.Xtream.Library;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests;
+
+public class DispatcharrBaseUrlTests
+{
+    [Fact]
+    public void EmptyDispatcharrUrl_FallsBackToTheXtreamUrl()
+    {
+        // Every install that worked before this field existed had them on one host, so an empty
+        // value has to keep meaning exactly that.
+        var provider = new ProviderConfig { BaseUrl = "http://same-host:8901" };
+
+        provider.EffectiveDispatcharrBaseUrl.Should().Be("http://same-host:8901");
+    }
+
+    [Fact]
+    public void ADedicatedUrl_IsUsedInsteadOfTheXtreamOne()
+    {
+        var provider = new ProviderConfig
+        {
+            BaseUrl = "http://xtream-host:8901",
+            DispatcharrBaseUrl = "http://dispatcharr-host:9191",
+        };
+
+        provider.EffectiveDispatcharrBaseUrl.Should().Be("http://dispatcharr-host:9191");
+    }
+
+    [Theory]
+    [InlineData("http://dispatcharr:9191/", "http://dispatcharr:9191")]
+    [InlineData("  http://dispatcharr:9191  ", "http://dispatcharr:9191")]
+    [InlineData("http://proxy/dispatcharr/", "http://proxy/dispatcharr")]
+    public void TheUrlIsNormalised_BecauseEveryCallerAppendsApiPaths(string configured, string expected)
+    {
+        new ProviderConfig { BaseUrl = "http://xtream:8901", DispatcharrBaseUrl = configured }
+            .EffectiveDispatcharrBaseUrl.Should().Be(expected);
+    }
+
+    [Fact]
+    public void APathIsKept_ForDispatcharrBehindAReverseProxy()
+    {
+        new ProviderConfig { BaseUrl = "http://xtream:8901", DispatcharrBaseUrl = "https://proxy/dispatcharr" }
+            .EffectiveDispatcharrBaseUrl.Should().Be("https://proxy/dispatcharr");
+    }
+
+    [Fact]
+    public void WhitespaceOnly_CountsAsUnset()
+    {
+        new ProviderConfig { BaseUrl = "http://xtream:8901", DispatcharrBaseUrl = "   " }
+            .EffectiveDispatcharrBaseUrl.Should().Be("http://xtream:8901");
+    }
+}

--- a/Jellyfin.Xtream.Library.Tests/Service/ChannelNumberingTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/ChannelNumberingTests.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #86. Providers number channels from 1 within each category, so the raw number is neither
+// a useful sort key across categories nor unique.
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Client.Models;
+using Jellyfin.Xtream.Library.Service;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class ChannelNumberingTests
+{
+    private static LiveStreamInfo Channel(int num, int? categoryId) =>
+        new() { StreamId = num, Name = $"Channel {num}", Num = num, CategoryId = categoryId };
+
+    [Fact]
+    public void Stride_DefaultsToAThousand_WhenChannelNumbersAreSmall()
+    {
+        ChannelNumbering.ComputeStride([Channel(1, 10), Channel(999, 10)])
+            .Should().Be(ChannelNumbering.MinimumStride);
+    }
+
+    [Fact]
+    public void Stride_Widens_SoNoCategoryCanSpillIntoTheNext()
+    {
+        // A provider numbering a channel 1000 would otherwise land it on top of category+1's first
+        // channel.
+        ChannelNumbering.ComputeStride([Channel(1, 10), Channel(1000, 10)]).Should().Be(10000);
+        ChannelNumbering.ComputeStride([Channel(45678, 10)]).Should().Be(100000);
+    }
+
+    [Fact]
+    public void Resolve_PrefixesTheCategoryId()
+    {
+        ChannelNumbering.Resolve(Channel(7, 3), 1000, byCategory: true).Should().Be(3007);
+    }
+
+    [Fact]
+    public void Resolve_LeavesTheNumberAlone_WhenTheFeatureIsOff()
+    {
+        ChannelNumbering.Resolve(Channel(7, 3), 1000, byCategory: false).Should().Be(7);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(-1)]
+    public void Resolve_LeavesTheNumberAlone_WhenThereIsNoCategoryToGroupBy(int? categoryId)
+    {
+        ChannelNumbering.Resolve(Channel(7, categoryId), 1000, byCategory: true).Should().Be(7);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToTheRawNumber_RatherThanOverflowing()
+    {
+        // Reported category ids already reach the 8000s; a widened stride on top of that can leave
+        // the int range, and a wrapped number would tune the wrong channel.
+        ChannelNumbering.Resolve(Channel(1, 9000), ChannelNumbering.MaximumStride, byCategory: true)
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public void Resolve_KeepsARealisticProviderInsideTheIntRange()
+    {
+        // The shape the reporter described: category ids in the 8000s.
+        ChannelNumbering.Resolve(Channel(12, 8123), 1000, byCategory: true).Should().Be(8123012);
+    }
+
+    [Fact]
+    public void TwoCategoriesNumberingFromOne_NoLongerCollide()
+    {
+        // This is the correctness half. The number is the key the tuner resolves hdhr_<number>
+        // back to a stream with, so a duplicate makes one of the two channels unreachable.
+        var sports = Channel(1, 5);
+        var news = Channel(1, 6);
+
+        var stride = ChannelNumbering.ComputeStride([sports, news]);
+
+        ChannelNumbering.Resolve(sports, stride, byCategory: true)
+            .Should().NotBe(ChannelNumbering.Resolve(news, stride, byCategory: true));
+    }
+
+    [Fact]
+    public void Ordering_GroupsEachCategoryTogether()
+    {
+        var channels = new List<LiveStreamInfo>
+        {
+            Channel(1, 20), Channel(1, 10), Channel(2, 20), Channel(2, 10),
+        };
+        var stride = ChannelNumbering.ComputeStride(channels);
+
+        var ordered = channels
+            .OrderBy(c => ChannelNumbering.Resolve(c, stride, byCategory: true))
+            .Select(c => (c.CategoryId, c.Num))
+            .ToList();
+
+        ordered.Should().Equal([(10, 1), (10, 2), (20, 1), (20, 2)]);
+    }
+}

--- a/Jellyfin.Xtream.Library.Tests/Service/ItemIdentityTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/ItemIdentityTests.cs
@@ -128,6 +128,84 @@ public class ItemIdentityTests
         identity.Source.Should().Be(ItemIdSource.Lookup);
     }
 
+    // Codex review finding: an id the provider confirmed for an item already on disk is proven,
+    // and treating it as Unknown left the regroup action with nothing it was allowed to merge.
+    [Fact]
+    public void AConfirmedProviderId_OutranksReadingItOffTheFolder()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-1234]",
+            "Movie (2024)",
+            fromExistingFolder: true,
+            NoOverrides,
+            providerTmdbId: 1234,
+            autoLookupTmdbId: null);
+
+        identity.Source.Should().Be(ItemIdSource.Provider, "the provider answered for it this run");
+        identity.TmdbId.Should().Be(1234);
+    }
+
+    // Codex review finding: an incremental run never reaches the loop for an unchanged movie, so
+    // writing an empty identity would erase what an earlier run worked out. One scheduled sync
+    // would then make regrouping impossible.
+    [Fact]
+    public void AnUntouchedMovie_KeepsWhatTheLastRunRecorded()
+    {
+        var previous = new ContentSnapshot();
+        previous.Movies[100] = new MovieSnapshot
+        {
+            StreamId = 100,
+            FolderName = "Movie (2024) [tmdbid-42]",
+            TmdbId = 42,
+            TmdbIdSource = ItemIdSource.Provider,
+        };
+
+        var result = StrmSyncService.EffectiveMovieIdentity(new(), previous, 100);
+
+        result.FolderName.Should().Be("Movie (2024) [tmdbid-42]");
+        result.TmdbId.Should().Be(42);
+        result.Source.Should().Be(ItemIdSource.Provider);
+    }
+
+    [Fact]
+    public void AMovieThisRunHandled_WinsOverTheOlderRecord()
+    {
+        // Including when it resolved to nothing: that is a fresh answer, not a missing one.
+        var previous = new ContentSnapshot();
+        previous.Movies[100] = new MovieSnapshot { StreamId = 100, FolderName = "Old", TmdbId = 42, TmdbIdSource = ItemIdSource.Provider };
+
+        var identities = new System.Collections.Concurrent.ConcurrentDictionary<int, ItemIdentity>();
+        identities[100] = new ItemIdentity("New", null, null, ItemIdSource.None);
+
+        var result = StrmSyncService.EffectiveMovieIdentity(identities, previous, 100);
+
+        result.FolderName.Should().Be("New");
+        result.TmdbId.Should().BeNull();
+        result.Source.Should().Be(ItemIdSource.None);
+    }
+
+    [Fact]
+    public void AMovieNeitherRunKnows_IsSimplyEmpty()
+    {
+        var result = StrmSyncService.EffectiveMovieIdentity(new(), null, 999);
+
+        result.FolderName.Should().BeEmpty();
+        result.TmdbId.Should().BeNull();
+        result.Source.Should().Be(ItemIdSource.None);
+    }
+
+    // Codex review finding: providers send 0 for "no id". Treating it as an id would put every
+    // such film in one folder and then offer that folder for an irreversible merge.
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(-1, false)]
+    [InlineData(1, true)]
+    [InlineData(1234, true)]
+    public void OnlyAPositiveIdIdentifiesSomething(int id, bool usable)
+    {
+        StrmSyncService.IsUsableMetadataId(id).Should().Be(usable);
+    }
+
     [Fact]
     public void TheNewFieldsSurviveTheSnapshotRoundTrip()
     {

--- a/Jellyfin.Xtream.Library.Tests/Service/ItemIdentityTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/ItemIdentityTests.cs
@@ -1,0 +1,165 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #88 groundwork. Grouping items by TMDB id needs to know, per stream, which folder it went
+// to and how trustworthy the id is. Only a provider-supplied id may be merged on: a name lookup can
+// give a live-action film and its animated remake the same id, which is the one case that must not
+// merge.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Service;
+using Jellyfin.Xtream.Library.Service.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class ItemIdentityTests
+{
+    private static readonly Dictionary<string, int> NoOverrides = [];
+
+    [Theory]
+    [InlineData("Some Movie (2024) [tmdbid-1234]", 1234)]
+    [InlineData("Some Movie (2024) [TMDBID-99]", 99)]
+    [InlineData("Weird [tmdbid-1] Name [tmdbid-2]", 1)]
+    public void TmdbId_IsReadBackOutOfAFolderName(string folderName, int expected)
+    {
+        FolderIdentity.TryParseTmdbId(folderName, out int id).Should().BeTrue();
+        id.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Some Movie (2024)")]
+    [InlineData("Some Movie [tmdbid-]")]
+    [InlineData("Some Movie [tvdbid-1234]")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void NoTmdbIdInTheName_IsNotAnId(string? folderName)
+    {
+        FolderIdentity.TryParseTmdbId(folderName, out int id).Should().BeFalse();
+        id.Should().Be(0);
+    }
+
+    [Fact]
+    public void TvdbId_IsReadBackToo_BecauseSeriesFoldersPreferIt()
+    {
+        FolderIdentity.TryParseTvdbId("Some Show [tvdbid-4321]", out int id).Should().BeTrue();
+        id.Should().Be(4321);
+    }
+
+    [Fact]
+    public void AnIdTooLargeForAnInt_IsRefusedRatherThanWrapped()
+    {
+        FolderIdentity.TryParseTmdbId("Some Movie [tmdbid-99999999999]", out int id).Should().BeFalse();
+        id.Should().Be(0);
+    }
+
+    [Fact]
+    public void AnOverrideOutranksEverything()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-1]",
+            "Movie (2024)",
+            fromExistingFolder: false,
+            new Dictionary<string, int> { ["Movie (2024)"] = 1 },
+            providerTmdbId: 2,
+            autoLookupTmdbId: 3);
+
+        identity.TmdbId.Should().Be(1);
+        identity.Source.Should().Be(ItemIdSource.Override);
+    }
+
+    [Fact]
+    public void AProviderIdOutranksALookup()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-2]", "Movie (2024)", fromExistingFolder: false, NoOverrides, 2, 3);
+
+        identity.TmdbId.Should().Be(2);
+        identity.Source.Should().Be(ItemIdSource.Provider);
+    }
+
+    [Fact]
+    public void ALookupIsRecordedAsSuch_SoGroupingCanRefuseIt()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-3]", "Movie (2024)", fromExistingFolder: false, NoOverrides, null, 3);
+
+        identity.TmdbId.Should().Be(3);
+        identity.Source.Should().Be(ItemIdSource.Lookup);
+    }
+
+    [Fact]
+    public void NoIdAtAll_IsRecordedAsNone()
+    {
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024)", "Movie (2024)", fromExistingFolder: false, NoOverrides, null, null);
+
+        identity.TmdbId.Should().BeNull();
+        identity.Source.Should().Be(ItemIdSource.None);
+    }
+
+    [Fact]
+    public void AnIdReadOffDisk_IsUnprovenEvenThoughItIsKnown()
+    {
+        // The folder is all that is left for a library synced before the snapshot carried this, and
+        // it does not say whether the provider gave the id or a lookup guessed it.
+        var identity = StrmSyncService.BuildMovieIdentity(
+            "Movie (2024) [tmdbid-1234]", "Movie (2024)", fromExistingFolder: true, NoOverrides, null, null);
+
+        identity.TmdbId.Should().Be(1234);
+        identity.Source.Should().Be(ItemIdSource.Unknown);
+        identity.FolderName.Should().Be("Movie (2024) [tmdbid-1234]");
+    }
+
+    [Fact]
+    public void ASeriesKeepsItsTvdbIdSeparateFromTmdb()
+    {
+        var identity = StrmSyncService.BuildSeriesIdentity(
+            "Show [tvdbid-77]", "Show", NoOverrides, providerTmdbId: null, autoLookupTvdbId: 77);
+
+        identity.TvdbId.Should().Be(77);
+        identity.TmdbId.Should().BeNull();
+        identity.Source.Should().Be(ItemIdSource.Lookup);
+    }
+
+    [Fact]
+    public void TheNewFieldsSurviveTheSnapshotRoundTrip()
+    {
+        var snapshot = new ContentSnapshot();
+        snapshot.Movies[100] = new MovieSnapshot
+        {
+            StreamId = 100,
+            Name = "Movie",
+            FolderName = "Movie (2024) [tmdbid-1234]",
+            TmdbId = 1234,
+            TmdbIdSource = ItemIdSource.Provider,
+        };
+
+        var restored = JsonConvert.DeserializeObject<ContentSnapshot>(JsonConvert.SerializeObject(snapshot))!;
+
+        restored.Movies[100].FolderName.Should().Be("Movie (2024) [tmdbid-1234]");
+        restored.Movies[100].TmdbId.Should().Be(1234);
+        restored.Movies[100].TmdbIdSource.Should().Be(ItemIdSource.Provider);
+    }
+
+    [Fact]
+    public void ASnapshotWrittenBeforeTheseFieldsExisted_StillLoads()
+    {
+        // Upgrade path: the fields are simply absent from an older snapshot file.
+        const string Old = """
+            {"Movies":{"100":{"StreamId":100,"Name":"Movie","Checksum":"abc"}},"Series":{}}
+            """;
+
+        var restored = JsonConvert.DeserializeObject<ContentSnapshot>(Old)!;
+
+        restored.Movies[100].FolderName.Should().BeEmpty();
+        restored.Movies[100].TmdbId.Should().BeNull();
+        restored.Movies[100].TmdbIdSource.Should().Be(ItemIdSource.None);
+    }
+}

--- a/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/StrmNameCollisionTests.cs
@@ -307,23 +307,286 @@ public class StrmNameCollisionTests : IDisposable
             .Should().HaveCount(1);
     }
 
+    // GitHub #90. Every version of a title (V1/V2/V3) resolves to one folder and therefore to one
+    // "<folder>.nfo", while the STRM files keep their version label and stay distinct. So the STRM
+    // claim never fires here and the NFO write was unguarded: whichever version finished last won,
+    // including a version whose metadata fetch had failed and had nothing to write.
+
+    private const string RaceNfo = "Race Movie (2024).nfo";
+
+    private static StreamInfo RaceVersion(int streamId, string label)
+        => new() { StreamId = streamId, Name = $"Race Movie (2024) - [{label}]", ContainerExtension = "mp4" };
+
+    private string RaceNfoPath => Path.Combine(_libraryPath, "Movies", "Race Movie (2024)", RaceNfo);
+
+    private void VodInfoReturns(int streamId, string plot)
+        => _client.Setup(c => c.GetVodInfoAsync(It.IsAny<ConnectionInfo>(), streamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VodInfoResponse { Info = new VodInfoDetails { Plot = plot } });
+
+    private void VodInfoFails(int streamId)
+        => _client.Setup(c => c.GetVodInfoAsync(It.IsAny<ConnectionInfo>(), streamId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("provider refused the info call"));
+
+    [Fact]
+    public async Task AVersionAddedLaterWhoseFetchFails_DoesNotStripTheExistingNfo()
+    {
+        VodInfoReturns(100, "The good plot");
+        VodInfoFails(200);
+
+        await RunMovieSyncAsync([RaceVersion(100, "V1")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+        (await File.ReadAllTextAsync(RaceNfoPath).ConfigureAwait(true))
+            .Should().Contain("The good plot", "the first run had working metadata");
+
+        // The provider adds V2 later and its info call fails. V2 is the only stream created this
+        // run, so it is the one that reaches the NFO write, with nothing to put in it.
+        await RunMovieSyncAsync([RaceVersion(100, "V1"), RaceVersion(200, "V2")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+
+        (await File.ReadAllTextAsync(RaceNfoPath).ConfigureAwait(true))
+            .Should().Contain("The good plot", "a failed fetch must not replace an NFO that already had metadata");
+        _log.Should().Contain(l => l.StartsWith("[Warning] Keeping the existing NFO", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheFailingVersionRunningFirst_StillLeavesTheRichNfo()
+    {
+        // A plain first-writer-wins claim would lock in the empty NFO here, because the version
+        // that cannot fetch anything is the one that takes the path.
+        VodInfoFails(100);
+        VodInfoReturns(200, "The good plot");
+
+        await RunMovieSyncAsync([RaceVersion(100, "V1"), RaceVersion(200, "V2")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+
+        (await File.ReadAllTextAsync(RaceNfoPath).ConfigureAwait(true))
+            .Should().Contain("The good plot", "the version with real metadata has to win regardless of order");
+    }
+
+    [Fact]
+    public async Task AFailedFetchWithNothingElseKnown_WritesNoNfoAndSaysWhy()
+    {
+        VodInfoFails(100);
+
+        var result = await RunMovieSyncAsync([RaceVersion(100, "V1")], useShippedDefaults: false, proactiveMediaInfo: true)
+            .ConfigureAwait(true);
+
+        // NfoWriter already refuses to write a file with no TMDB id, no media info and no metadata,
+        // so the outcome here is no NFO rather than an empty one. What changed is that the reason is
+        // now visible instead of being logged at Debug.
+        File.Exists(RaceNfoPath).Should().BeFalse("there was nothing to put in it");
+        result.Errors.Should().Be(0, "a provider that will not answer the info call is not a sync failure");
+        _log.Should().Contain(l => l.StartsWith("[Warning] Failed to fetch VOD info for NFO", StringComparison.Ordinal));
+    }
+    // GitHub #88. Two differently titled streams the provider reports under one TMDB id have to
+    // end up as two versions of one film, not two entries. Metadata lookup is off in this harness,
+    // which is the case that matters: grouping keys on the provider's own id, so it has to work
+    // without the name-based lookup being enabled.
+    [Fact]
+    public async Task MoviesSharingAProviderTmdbId_LandInOneFolder()
+    {
+        VodInfoWithTmdbId(100, "42");
+        VodInfoWithTmdbId(200, "42");
+
+        var result = await RunMovieSyncAsync(
+            [
+                new StreamInfo { StreamId = 100, Name = "Alpha Movie (2024)", ContainerExtension = "mp4" },
+                new StreamInfo { StreamId = 200, Name = "Beta Movie (2024)", ContainerExtension = "mp4" },
+            ],
+            useShippedDefaults: false,
+            groupByTmdbId: true).ConfigureAwait(true);
+
+        var grouped = Path.Combine(_libraryPath, "Movies", "Alpha Movie (2024) [tmdbid-42]");
+        var written = Directory.GetFiles(grouped, "*.strm").Select(Path.GetFileName).OrderBy(f => f).ToList();
+
+        written.Should().Equal(
+            "Alpha Movie (2024) [tmdbid-42] - 200.strm",
+            "Alpha Movie (2024) [tmdbid-42].strm");
+        Directory.Exists(Path.Combine(_libraryPath, "Movies", "Beta Movie (2024)")).Should().BeFalse();
+        result.MovieNameCollisions.Should().Be(0, "sharing a folder is the feature, not a collision");
+        result.Errors.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task WithGroupingOff_TheSameTwoMoviesStayApart()
+    {
+        VodInfoWithTmdbId(100, "42");
+        VodInfoWithTmdbId(200, "42");
+
+        await RunMovieSyncAsync(
+            [
+                new StreamInfo { StreamId = 100, Name = "Alpha Movie (2024)", ContainerExtension = "mp4" },
+                new StreamInfo { StreamId = 200, Name = "Beta Movie (2024)", ContainerExtension = "mp4" },
+            ],
+            useShippedDefaults: false).ConfigureAwait(true);
+
+        Directory.GetDirectories(Path.Combine(_libraryPath, "Movies")).Should().HaveCount(2);
+    }
+
+    // Codex review finding: providers send 0 for "no id". Treating it as an id would collapse
+    // every such film into one folder, and then offer that folder for an irreversible merge.
+    [Fact]
+    public async Task MoviesReportingTmdbIdZero_AreNotGroupedTogether()
+    {
+        VodInfoWithTmdbId(100, "0");
+        VodInfoWithTmdbId(200, "0");
+
+        await RunMovieSyncAsync(
+            [
+                new StreamInfo { StreamId = 100, Name = "Alpha Movie (2024)", ContainerExtension = "mp4" },
+                new StreamInfo { StreamId = 200, Name = "Beta Movie (2024)", ContainerExtension = "mp4" },
+            ],
+            useShippedDefaults: false,
+            groupByTmdbId: true).ConfigureAwait(true);
+
+        Directory.GetDirectories(Path.Combine(_libraryPath, "Movies"))
+            .Should().HaveCount(2, "0 means the provider has no id, not that these are the same film");
+        Directory.Exists(Path.Combine(_libraryPath, "Movies", "Alpha Movie (2024) [tmdbid-0]"))
+            .Should().BeFalse("a folder named after a non-id helps nobody");
+    }
+
+    // Codex review finding: a grouped guest lives in the folder its owner named, so the orphan
+    // protection that looks up the guest's own base name cannot find it. When the owner leaves the
+    // provider's catalogue, cleanup would delete a file the provider still lists.
+    [Fact]
+    public async Task AGroupedGuestSurvivesCleanup_WhenItsOwnerLeavesTheCatalogue()
+    {
+        VodInfoWithTmdbId(100, "42");
+        VodInfoWithTmdbId(200, "42");
+
+        await RunMovieSyncAsync(
+            [
+                new StreamInfo { StreamId = 100, Name = "Alpha Movie (2024)", ContainerExtension = "mp4" },
+                new StreamInfo { StreamId = 200, Name = "Beta Movie (2024)", ContainerExtension = "mp4" },
+            ],
+            useShippedDefaults: false,
+            groupByTmdbId: true).ConfigureAwait(true);
+
+        var guestFile = Path.Combine(
+            _libraryPath, "Movies", "Alpha Movie (2024) [tmdbid-42]", "Alpha Movie (2024) [tmdbid-42] - 200.strm");
+        File.Exists(guestFile).Should().BeTrue("the first run has to have produced the grouped file");
+
+        // The provider drops Alpha. Beta is unchanged, so an incremental run skips it entirely and
+        // only the orphan protection stands between its file and cleanup.
+        await RunMovieSyncAsync(
+            [new StreamInfo { StreamId = 200, Name = "Beta Movie (2024)", ContainerExtension = "mp4" }],
+            useShippedDefaults: true,
+            groupByTmdbId: true,
+            cleanupOrphans: true).ConfigureAwait(true);
+
+        File.Exists(guestFile).Should().BeTrue("the provider still lists this stream");
+
+        // The other half of the same rule: only the guest's own file is spared. Protecting the
+        // whole shared folder would keep the departed owner's file in the library forever.
+        File.Exists(Path.Combine(
+            _libraryPath, "Movies", "Alpha Movie (2024) [tmdbid-42]", "Alpha Movie (2024) [tmdbid-42].strm"))
+            .Should().BeFalse("the provider stopped listing that stream");
+    }
+
+    // Codex review finding: two streams can share a title and a year. Deciding who owns the folder
+    // by comparing names made neither of them a guest, so both claimed the same file name and one
+    // was refused, while its identity was still recorded and an incremental run never retried it.
+    [Fact]
+    public async Task TwoStreamsSharingATitleAndAnId_BothSurviveWhenGrouped()
+    {
+        VodInfoWithTmdbId(100, "42");
+        VodInfoWithTmdbId(200, "42");
+
+        var result = await RunMovieSyncAsync(
+            [
+                new StreamInfo { StreamId = 100, Name = "Same Movie (2024)", ContainerExtension = "mp4" },
+                new StreamInfo { StreamId = 200, Name = "Same Movie (2024)", ContainerExtension = "mp4" },
+            ],
+            useShippedDefaults: false,
+            groupByTmdbId: true).ConfigureAwait(true);
+
+        var folder = Path.Combine(_libraryPath, "Movies", "Same Movie (2024) [tmdbid-42]");
+        Directory.GetFiles(folder, "*.strm").Select(Path.GetFileName).OrderBy(f => f).Should().Equal(
+            "Same Movie (2024) [tmdbid-42] - 200.strm",
+            "Same Movie (2024) [tmdbid-42].strm");
+        result.MovieNameCollisions.Should().Be(0, "the provider offering the film twice is what grouping is for");
+        result.MoviesCreated.Should().Be(2);
+    }
+
+    // Codex review finding: on a later run both same-title streams find the shared folder, and
+    // without restoring who owns it neither counted as a guest, so both built the plain file name
+    // and one was refused as a collision.
+    [Fact]
+    public async Task TwoStreamsSharingATitle_KeepTheirOwnFilesOnEveryRun()
+    {
+        VodInfoWithTmdbId(100, "42");
+        VodInfoWithTmdbId(200, "42");
+
+        StreamInfo[] Streams() =>
+        [
+            new StreamInfo { StreamId = 100, Name = "Same Movie (2024)", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "Same Movie (2024)", ContainerExtension = "mp4" },
+        ];
+
+        await RunMovieSyncAsync(Streams(), useShippedDefaults: false, groupByTmdbId: true).ConfigureAwait(true);
+        var second = await RunMovieSyncAsync(Streams(), useShippedDefaults: false, groupByTmdbId: true).ConfigureAwait(true);
+
+        var folder = Path.Combine(_libraryPath, "Movies", "Same Movie (2024) [tmdbid-42]");
+        Directory.GetFiles(folder, "*.strm").Select(Path.GetFileName).OrderBy(f => f).Should().Equal(
+            "Same Movie (2024) [tmdbid-42] - 200.strm",
+            "Same Movie (2024) [tmdbid-42].strm");
+        second.MovieNameCollisions.Should().Be(0, "the second run must not refuse a file it wrote itself");
+    }
+
+    // Codex review finding: the provider failing to answer for a moment must not dissolve a group
+    // that already exists, or the guest goes back to the plain name, collides with its owner and
+    // has its record downgraded to unproven.
+    [Fact]
+    public async Task AnEstablishedGroupSurvivesTheProviderNotAnswering()
+    {
+        VodInfoWithTmdbId(100, "42");
+        VodInfoWithTmdbId(200, "42");
+
+        StreamInfo[] Streams() =>
+        [
+            new StreamInfo { StreamId = 100, Name = "Same Movie (2024)", ContainerExtension = "mp4" },
+            new StreamInfo { StreamId = 200, Name = "Same Movie (2024)", ContainerExtension = "mp4" },
+        ];
+
+        await RunMovieSyncAsync(Streams(), useShippedDefaults: false, groupByTmdbId: true).ConfigureAwait(true);
+
+        // The info call starts failing for both streams.
+        _client.Setup(c => c.GetVodInfoAsync(It.IsAny<ConnectionInfo>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("provider unavailable"));
+
+        var second = await RunMovieSyncAsync(Streams(), useShippedDefaults: false, groupByTmdbId: true).ConfigureAwait(true);
+
+        var folder = Path.Combine(_libraryPath, "Movies", "Same Movie (2024) [tmdbid-42]");
+        Directory.GetFiles(folder, "*.strm").Select(Path.GetFileName).OrderBy(f => f).Should().Equal(
+            "Same Movie (2024) [tmdbid-42] - 200.strm",
+            "Same Movie (2024) [tmdbid-42].strm");
+        second.MovieNameCollisions.Should().Be(0, "the group the provider confirmed earlier still stands");
+    }
+
+    private void VodInfoWithTmdbId(int streamId, string tmdbId)
+        => _client.Setup(c => c.GetVodInfoAsync(It.IsAny<ConnectionInfo>(), streamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VodInfoResponse { Info = new VodInfoDetails { TmdbId = tmdbId } });
+
     private Task<SyncResult> RunMovieSyncAsync(params StreamInfo[] streams)
         => RunMovieSyncAsync(streams, useShippedDefaults: false);
 
-    private async Task<SyncResult> RunMovieSyncAsync(StreamInfo[] streams, bool useShippedDefaults)
+    private async Task<SyncResult> RunMovieSyncAsync(StreamInfo[] streams, bool useShippedDefaults, bool proactiveMediaInfo = false, bool groupByTmdbId = false, bool cleanupOrphans = false)
     {
         _client.Setup(c => c.GetVodCategoryAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Category> { new() { CategoryId = 1, CategoryName = "Movies" } });
         _client.Setup(c => c.GetVodStreamsByCategoryAsync(It.IsAny<ConnectionInfo>(), 1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<StreamInfo>(streams));
 
-        return await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults).ConfigureAwait(true);
+        return await RunSyncAsync(syncMovies: true, syncSeries: false, useShippedDefaults, providerCount: 1, proactiveMediaInfo, groupByTmdbId, cleanupOrphans).ConfigureAwait(true);
     }
 
     private Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults)
         => RunSyncAsync(syncMovies, syncSeries, useShippedDefaults, providerCount: 1);
 
-    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount)
+    private Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount)
+        => RunSyncAsync(syncMovies, syncSeries, useShippedDefaults, providerCount, proactiveMediaInfo: false, groupByTmdbId: false, cleanupOrphans: false);
+
+    private async Task<SyncResult> RunSyncAsync(bool syncMovies, bool syncSeries, bool useShippedDefaults, int providerCount, bool proactiveMediaInfo, bool groupByTmdbId, bool cleanupOrphans)
     {
         var appPaths = new Mock<IServerApplicationPaths>();
         appPaths.Setup(p => p.PluginConfigurationsPath).Returns(_libraryPath);
@@ -344,10 +607,12 @@ public class StrmNameCollisionTests : IDisposable
             LibraryPath = _libraryPath,
             SyncMovies = syncMovies,
             SyncSeries = syncSeries,
-            CleanupOrphans = false,
+            CleanupOrphans = cleanupOrphans,
             EnableIncrementalSync = useShippedDefaults,
             SmartSkipExisting = useShippedDefaults,
             DownloadArtworkForUnmatched = false,
+            EnableProactiveMediaInfo = proactiveMediaInfo,
+            GroupMoviesByTmdbId = groupByTmdbId,
             SyncParallelism = 1,
         }).ToList();
         plugin.Configuration.EnableLiveTv = false;

--- a/Jellyfin.Xtream.Library.Tests/Service/TmdbGroupingTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/TmdbGroupingTests.cs
@@ -1,0 +1,88 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// GitHub #88. Which folders hold the same film, worked out before anything is touched.
+
+using FluentAssertions;
+using Jellyfin.Xtream.Library.Service;
+using Jellyfin.Xtream.Library.Service.Models;
+using Xunit;
+
+namespace Jellyfin.Xtream.Library.Tests.Service;
+
+public class TmdbGroupingTests
+{
+    private static ContentSnapshot SnapshotWith(params MovieSnapshot[] movies)
+    {
+        var snapshot = new ContentSnapshot();
+        foreach (var movie in movies)
+        {
+            snapshot.Movies[movie.StreamId] = movie;
+        }
+
+        return snapshot;
+    }
+
+    private static MovieSnapshot Movie(int streamId, int? tmdbId, ItemIdSource source, string folder) =>
+        new() { StreamId = streamId, TmdbId = tmdbId, TmdbIdSource = source, FolderName = folder };
+
+    // Codex review finding: which stream ends up owning a folder depends on the order a run
+    // processed them. A later run that worked the owner out again could pick a different one, hand
+    // the plain file name to a second stream, and overwrite the first one's file.
+    [Fact]
+    public void TheRecordedOwnerIsHonoured_EvenWhenItIsNotTheLowestStreamId()
+    {
+        var snapshot = SnapshotWith(
+            new MovieSnapshot { StreamId = 100, TmdbId = 42, TmdbIdSource = ItemIdSource.Provider, FolderName = "The Film 4K (2024) [tmdbid-42]", GroupOwnerStreamId = 200 },
+            new MovieSnapshot { StreamId = 200, TmdbId = 42, TmdbIdSource = ItemIdSource.Provider, FolderName = "The Film 4K (2024) [tmdbid-42]", GroupOwnerStreamId = 200 });
+
+        TmdbGrouping.BuildFolderMap(snapshot)[42]
+            .Should().Be((200, "The Film 4K (2024) [tmdbid-42]"), "the files on disk were named by 200");
+    }
+
+    [Fact]
+    public void WithNothingRecorded_TheLowestStreamIdStillDecides()
+    {
+        // Snapshots written before ownership was recorded fall back to the old rule.
+        var map = TmdbGrouping.BuildFolderMap(SnapshotWith(
+            Movie(200, 42, ItemIdSource.Provider, "The Film (2024) [tmdbid-42]"),
+            Movie(100, 42, ItemIdSource.Provider, "The Film (2024) [tmdbid-42]")));
+
+        map[42].OwnerStreamId.Should().Be(100);
+    }
+
+    [Theory]
+    [InlineData(ItemIdSource.Provider, true)]
+    [InlineData(ItemIdSource.Override, true)]
+    [InlineData(ItemIdSource.Lookup, false)]
+    [InlineData(ItemIdSource.Unknown, false)]
+    [InlineData(ItemIdSource.None, false)]
+    public void OnlyAnIdTheProviderGaveOrTheUserPinned_MayBeGroupedOn(ItemIdSource source, bool groupable)
+    {
+        TmdbGrouping.IsGroupable(source).Should().Be(groupable);
+    }
+
+    [Fact]
+    public void TheFolderMapPinsTheChoiceForLaterSyncs()
+    {
+        var map = TmdbGrouping.BuildFolderMap(SnapshotWith(
+            Movie(200, 42, ItemIdSource.Provider, "The Film 4K (2024) [tmdbid-42]"),
+            Movie(100, 42, ItemIdSource.Provider, "The Film (2024) [tmdbid-42]"),
+            Movie(300, 43, ItemIdSource.Lookup, "Guessed (2024) [tmdbid-43]")));
+
+        map.Should().ContainKey(42).WhoseValue.Should().Be(
+            (100, "The Film (2024) [tmdbid-42]"),
+            "the lowest stream id owns the folder, and ownership is what decides who keeps the plain file name");
+        map.Should().NotContainKey(43, "a guessed id must not steer new movies either");
+    }
+
+    [Fact]
+    public void NoSnapshotMeansNoMap()
+    {
+        TmdbGrouping.BuildFolderMap(null).Should().BeEmpty();
+    }
+}

--- a/Jellyfin.Xtream.Library.Tests/Service/XtreamTunerHostTests.cs
+++ b/Jellyfin.Xtream.Library.Tests/Service/XtreamTunerHostTests.cs
@@ -193,6 +193,57 @@ public class XtreamTunerHostTests : IDisposable
         result[2].ImageUrl.Should().Be("http://127.0.0.1:8096/XtreamLibrary/ChannelLogo/300");
     }
 
+    // GitHub #86. The channel number is both the guide's sort key and the key the tuner resolves
+    // hdhr_<number> back to a stream with, so a provider that numbers from 1 inside every category
+    // interleaves the guide and, worse, makes one of two same-numbered channels unreachable.
+    [Fact]
+    public async Task GetChannels_PrefixesTheCategoryId_WhenNumberByCategoryIsEnabled()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.EnableLiveTv = true;
+        config.EnableNativeTuner = true;
+        config.EnableChannelNameCleaning = false;
+        config.LiveTvNumberByCategory = true;
+
+        _mockClient
+            .Setup(c => c.GetAllLiveStreamsAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveStreamInfo>
+            {
+                new() { StreamId = 100, Name = "Sports One", Num = 1, CategoryId = 5 },
+                new() { StreamId = 200, Name = "News One", Num = 1, CategoryId = 6 },
+                new() { StreamId = 300, Name = "Sports Two", Num = 2, CategoryId = 5 },
+            });
+
+        var result = await _tunerHost.GetChannels(false, CancellationToken.None);
+
+        result.Select(c => c.Number).Should().Equal("5001", "6001", "5002");
+        result.Select(c => c.Number).Should().OnlyHaveUniqueItems(
+            "a duplicate number silently makes one of the two channels unreachable");
+    }
+
+    [Fact]
+    public async Task GetChannels_KeepsProviderNumbers_WhenNumberByCategoryIsOff()
+    {
+        var config = Plugin.Instance.Configuration;
+        config.EnableLiveTv = true;
+        config.EnableNativeTuner = true;
+        config.EnableChannelNameCleaning = false;
+        config.LiveTvNumberByCategory = false;
+
+        _mockClient
+            .Setup(c => c.GetAllLiveStreamsAsync(It.IsAny<ConnectionInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveStreamInfo>
+            {
+                new() { StreamId = 100, Name = "Sports One", Num = 1, CategoryId = 5 },
+                new() { StreamId = 200, Name = "News One", Num = 1, CategoryId = 6 },
+            });
+
+        var result = await _tunerHost.GetChannels(false, CancellationToken.None);
+
+        // Unchanged behaviour for anyone who does not turn the option on, collision included.
+        result.Select(c => c.Number).Should().Equal("1", "1");
+    }
+
     // BUG-011: native tuner channels were ungrouped because ChannelGroup was never set.
     [Fact]
     public async Task GetChannels_SetsChannelGroup_FromCategoryName()

--- a/Jellyfin.Xtream.Library/Api/SyncController.cs
+++ b/Jellyfin.Xtream.Library/Api/SyncController.cs
@@ -312,7 +312,7 @@ public class SyncController : ControllerBase
         try
         {
             _dispatcharrClient.Configure(provider.DispatcharrApiUser, provider.DispatcharrApiPass);
-            var success = await _dispatcharrClient.TestConnectionAsync(provider.BaseUrl, cancellationToken).ConfigureAwait(false);
+            var success = await _dispatcharrClient.TestConnectionAsync(provider.EffectiveDispatcharrBaseUrl, cancellationToken).ConfigureAwait(false);
 
             if (success)
             {

--- a/Jellyfin.Xtream.Library/Client/DispatcharrClient.cs
+++ b/Jellyfin.Xtream.Library/Client/DispatcharrClient.cs
@@ -83,7 +83,7 @@ public class DispatcharrClient : IDispatcharrClient
     {
         try
         {
-            var json = await GetAuthenticatedAsync($"{baseUrl}/api/vod/movies/{movieId}/", cancellationToken).ConfigureAwait(false);
+            var json = await GetAuthenticatedAsync(baseUrl, $"{baseUrl}/api/vod/movies/{movieId}/", cancellationToken).ConfigureAwait(false);
             if (json == null)
             {
                 return null;
@@ -103,7 +103,7 @@ public class DispatcharrClient : IDispatcharrClient
     {
         try
         {
-            var json = await GetAuthenticatedAsync($"{baseUrl}/api/vod/movies/{movieId}/providers/", cancellationToken).ConfigureAwait(false);
+            var json = await GetAuthenticatedAsync(baseUrl, $"{baseUrl}/api/vod/movies/{movieId}/providers/", cancellationToken).ConfigureAwait(false);
             if (json == null)
             {
                 return new List<DispatcharrMovieProvider>();
@@ -133,12 +133,11 @@ public class DispatcharrClient : IDispatcharrClient
         }
     }
 
-    private async Task<string?> GetAuthenticatedAsync(string url, CancellationToken cancellationToken)
+    private async Task<string?> GetAuthenticatedAsync(string baseUrl, string url, CancellationToken cancellationToken)
     {
-        // Extract base URL from the full URL for token acquisition
-        var uri = new Uri(url);
-        var baseUrl = $"{uri.Scheme}://{uri.Authority}";
-
+        // The base URL is passed in rather than derived from the request URL. Deriving it as
+        // scheme://authority dropped any path, so a Dispatcharr behind a reverse proxy on a subpath
+        // had its data calls sent to the right place and its login sent to the wrong one (#83).
         await EnsureTokenAsync(baseUrl, cancellationToken).ConfigureAwait(false);
 
         if (_accessToken == null)

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.html
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.html
@@ -633,6 +633,16 @@
                                 </div>
                                 <div id="dispatcharrSettings" style="display: none;">
                                     <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="txtDispatcharrBaseUrl">Dispatcharr URL</label>
+                                        <input is="emby-input" type="text" id="txtDispatcharrBaseUrl" name="DispatcharrBaseUrl"
+                                            placeholder="http://dispatcharr-host:9191" />
+                                        <div class="fieldDescription">
+                                            Leave empty if Dispatcharr answers on the same address as the Xtream URL above.
+                                            Fill this in when it runs on a different host, port or path, otherwise the login
+                                            is sent to the Xtream server and fails with "JWT login failed with status NotFound".
+                                        </div>
+                                    </div>
+                                    <div class="inputContainer">
                                         <label class="inputLabel inputLabelUnfocused" for="txtDispatcharrApiUser">API Username</label>
                                         <input is="emby-input" type="text" id="txtDispatcharrApiUser" name="DispatcharrApiUser" />
                                         <div class="fieldDescription">
@@ -715,6 +725,24 @@
                                 </label>
                                 <div class="fieldDescription checkboxFieldDescription">
                                     Enable syncing of movies and VOD content.
+                                </div>
+                            </div>
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input is="emby-checkbox" type="checkbox" id="chkGroupMoviesByTmdbId" name="GroupMoviesByTmdbId" />
+                                    <span>Group movies with the same TMDB id into one folder</span>
+                                </label>
+                                <div class="fieldDescription checkboxFieldDescription">
+                                    Providers often carry the same film several times, in different qualities or
+                                    languages. With this on, copies your provider reports under the same TMDB id are
+                                    written to one folder, so Jellyfin shows them as versions of one film instead of
+                                    separate entries.
+                                    <br />
+                                    Only ids your provider supplies are grouped. An id found by searching on the title
+                                    is left alone, because a search can give a film and its remake the same id.
+                                    <br />
+                                    This applies to movies added from now on. Films already in your library stay in
+                                    the folders they are in: nothing on your disk is moved or renamed.
                                 </div>
                             </div>
                         </div>
@@ -1036,6 +1064,24 @@
                             </div>
                         </div>
 
+                        <div class="verticalSection">
+                            <h3 class="sectionTitle">Channel Order</h3>
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input is="emby-checkbox" type="checkbox" id="chkLiveTvNumberByCategory" name="LiveTvNumberByCategory" />
+                                    <span>Group channel numbers by category</span>
+                                </label>
+                                <div class="fieldDescription checkboxFieldDescription">
+                                    Providers number channels from 1 inside every category, so channel 1 of Sports,
+                                    News and Movies all end up next to each other in the guide. Turn this on to put
+                                    the category in front of the number, so each category's channels stay together.
+                                    This also stops two channels sharing a number, which could make one of them
+                                    unreachable.
+                                    <br />
+                                    Every channel gets a new number, so refresh the guide after changing this.
+                                </div>
+                            </div>
+                        </div>
                         <div class="verticalSection">
                             <h3 class="sectionTitle">Title Cleaning</h3>
                             <div class="checkboxContainer checkboxContainer-withDescription">

--- a/Jellyfin.Xtream.Library/Configuration/Web/config.js
+++ b/Jellyfin.Xtream.Library/Configuration/Web/config.js
@@ -160,6 +160,8 @@ const XtreamLibraryConfig = {
         document.getElementById('chkEnableProactiveMediaInfo').checked = p.EnableProactiveMediaInfo || false;
 
         document.getElementById('chkEnableDispatcharrMode').checked = p.EnableDispatcharrMode || false;
+        document.getElementById('txtDispatcharrBaseUrl').value = p.DispatcharrBaseUrl || '';
+        document.getElementById('chkGroupMoviesByTmdbId').checked = p.GroupMoviesByTmdbId === true;
         document.getElementById('txtDispatcharrApiUser').value = p.DispatcharrApiUser || '';
         document.getElementById('txtDispatcharrApiPass').value = p.DispatcharrApiPass || '';
         self.updateDispatcharrVisibility();
@@ -262,6 +264,8 @@ const XtreamLibraryConfig = {
         p.EnableProactiveMediaInfo = document.getElementById('chkEnableProactiveMediaInfo').checked;
 
         p.EnableDispatcharrMode = document.getElementById('chkEnableDispatcharrMode').checked;
+        p.DispatcharrBaseUrl = document.getElementById('txtDispatcharrBaseUrl').value.trim().replace(/\/$/, '');
+        p.GroupMoviesByTmdbId = document.getElementById('chkGroupMoviesByTmdbId').checked;
         p.DispatcharrApiUser = document.getElementById('txtDispatcharrApiUser').value.trim();
         p.DispatcharrApiPass = document.getElementById('txtDispatcharrApiPass').value.trim();
     },
@@ -338,6 +342,7 @@ const XtreamLibraryConfig = {
 
             // Title cleaning
             document.getElementById('chkEnableChannelNameCleaning').checked = config.EnableChannelNameCleaning !== false;
+            document.getElementById('chkLiveTvNumberByCategory').checked = config.LiveTvNumberByCategory === true;
             document.getElementById('txtChannelRemoveTerms').value = config.ChannelRemoveTerms || '';
 
             // Channel overrides
@@ -422,6 +427,7 @@ const XtreamLibraryConfig = {
 
             // Title cleaning
             config.EnableChannelNameCleaning = document.getElementById('chkEnableChannelNameCleaning').checked;
+            config.LiveTvNumberByCategory = document.getElementById('chkLiveTvNumberByCategory').checked;
             config.ChannelRemoveTerms = document.getElementById('txtChannelRemoveTerms').value;
 
             // Channel overrides

--- a/Jellyfin.Xtream.Library/Plugin.cs
+++ b/Jellyfin.Xtream.Library/Plugin.cs
@@ -128,6 +128,8 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             EnableProactiveMediaInfo = config.EnableProactiveMediaInfo,
             FallbackToYearlessLookup = config.FallbackToYearlessLookup,
             EnableDispatcharrMode = config.EnableDispatcharrMode,
+            DispatcharrBaseUrl = config.DispatcharrBaseUrl,
+            GroupMoviesByTmdbId = config.GroupMoviesByTmdbId,
             DispatcharrApiUser = config.DispatcharrApiUser,
             DispatcharrApiPass = config.DispatcharrApiPass,
             EnableIncrementalSync = config.EnableIncrementalSync,
@@ -340,6 +342,8 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         target.EnableProactiveMediaInfo = source.EnableProactiveMediaInfo;
         target.FallbackToYearlessLookup = source.FallbackToYearlessLookup;
         target.EnableDispatcharrMode = source.EnableDispatcharrMode;
+        target.DispatcharrBaseUrl = source.DispatcharrBaseUrl;
+        target.GroupMoviesByTmdbId = source.GroupMoviesByTmdbId;
         target.DispatcharrApiUser = source.DispatcharrApiUser;
         target.DispatcharrApiPass = source.DispatcharrApiPass;
         target.EnableIncrementalSync = source.EnableIncrementalSync;

--- a/Jellyfin.Xtream.Library/PluginConfiguration.cs
+++ b/Jellyfin.Xtream.Library/PluginConfiguration.cs
@@ -209,6 +209,16 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool EnableChannelNameCleaning { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether channel numbers are prefixed with the category id
+    /// so the guide groups by category (GitHub #86).
+    /// <para>
+    /// Off by default: turning it on renumbers every channel, and Jellyfin keeps the old numbers in
+    /// its own database until the guide is refreshed.
+    /// </para>
+    /// </summary>
+    public bool LiveTvNumberByCategory { get; set; }
+
+    /// <summary>
     /// Gets or sets custom terms to remove from channel names. One term per line.
     /// </summary>
     public string ChannelRemoveTerms { get; set; } = string.Empty;
@@ -315,7 +325,15 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>Gets or sets the legacy Dispatcharr mode flag. Migrated to Providers[0].</summary>
     public bool EnableDispatcharrMode { get; set; }
 
+    /// <summary>Gets or sets the legacy group-movies-by-TMDB-id flag. Migrated to Providers[0].</summary>
+    public bool GroupMoviesByTmdbId { get; set; }
+
     /// <summary>Gets or sets the legacy Dispatcharr API user. Migrated to Providers[0].</summary>
+    public string DispatcharrBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Dispatcharr REST API username.
+    /// </summary>
     public string DispatcharrApiUser { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the legacy Dispatcharr API password. Migrated to Providers[0].</summary>

--- a/Jellyfin.Xtream.Library/ProviderConfig.cs
+++ b/Jellyfin.Xtream.Library/ProviderConfig.cs
@@ -203,9 +203,47 @@ public class ProviderConfig
     // =====================
 
     /// <summary>
+    /// Gets or sets a value indicating whether movies sharing a provider-supplied TMDB id are
+    /// written to one folder, so Jellyfin shows them as versions of a single film (GitHub #88).
+    /// <para>
+    /// Only ids the provider itself returned are grouped. An id a name lookup guessed is left
+    /// alone, because a lookup can hand a film and its remake the same id.
+    /// </para>
+    /// <para>
+    /// Turning this on affects newly synced movies only. Folders already on disk are moved by the
+    /// separate regroup action, so a sync never renames anything on its own.
+    /// </para>
+    /// </summary>
+    public bool GroupMoviesByTmdbId { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether Dispatcharr mode is enabled.
     /// </summary>
     public bool EnableDispatcharrMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base URL of the Dispatcharr instance, protocol and port included.
+    /// <para>
+    /// Empty means "the same host as <see cref="BaseUrl"/>", which is what every install did before
+    /// this field existed. Dispatcharr on a different host or port was simply broken: the JWT login
+    /// was posted to the Xtream endpoint, which has no such route and answers 404 (GitHub #83).
+    /// </para>
+    /// </summary>
+    public string DispatcharrBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the URL Dispatcharr calls actually go to: the dedicated one when set, otherwise the
+    /// Xtream base URL. Any trailing slash is removed, because every caller appends "/api/...".
+    /// A path is kept, so Dispatcharr behind a reverse proxy on a subpath works.
+    /// </summary>
+    public string EffectiveDispatcharrBaseUrl
+    {
+        get
+        {
+            string configured = string.IsNullOrWhiteSpace(DispatcharrBaseUrl) ? BaseUrl : DispatcharrBaseUrl;
+            return (configured ?? string.Empty).Trim().TrimEnd('/');
+        }
+    }
 
     /// <summary>
     /// Gets or sets the Dispatcharr REST API username.

--- a/Jellyfin.Xtream.Library/Service/ChannelNumbering.cs
+++ b/Jellyfin.Xtream.Library/Service/ChannelNumbering.cs
@@ -1,0 +1,97 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using Jellyfin.Xtream.Library.Client.Models;
+
+namespace Jellyfin.Xtream.Library.Service;
+
+/// <summary>
+/// Builds the channel number Jellyfin sorts and tunes by (GitHub #86).
+/// <para>
+/// Providers number channels from 1 within each category, so the raw number is not unique across a
+/// multi-category selection. Two things follow. The guide interleaves categories, because Jellyfin
+/// sorts on the number rather than on the group. And the number is the key
+/// <see cref="XtreamTunerHost"/> resolves <c>hdhr_&lt;number&gt;</c> back to a stream with, so a
+/// duplicate silently makes one of the two channels unreachable.
+/// </para>
+/// <para>
+/// Prefixing the category id fixes both. The category id is used rather than a running index so the
+/// numbers stay stable when the provider adds a category later.
+/// </para>
+/// </summary>
+internal static class ChannelNumbering
+{
+    /// <summary>
+    /// Smallest room reserved per category. Widened when a provider numbers channels beyond it.
+    /// </summary>
+    internal const int MinimumStride = 1000;
+
+    /// <summary>
+    /// Ceiling for the stride. A stride beyond this leaves no room for the category id inside an
+    /// int, and channel numbers are an int all the way through Jellyfin.
+    /// </summary>
+    internal const int MaximumStride = 1000000;
+
+    /// <summary>
+    /// Picks the multiplier for the category id: the smallest power of ten that still fits every
+    /// channel number in the list, so no category can spill into the next one's range.
+    /// </summary>
+    /// <param name="channels">Channels about to be numbered.</param>
+    /// <returns>The stride to pass to <see cref="Resolve"/>.</returns>
+    internal static int ComputeStride(IEnumerable<LiveStreamInfo> channels)
+    {
+        int highest = 0;
+        foreach (var channel in channels)
+        {
+            if (channel.Num > highest)
+            {
+                highest = channel.Num;
+            }
+        }
+
+        int stride = MinimumStride;
+        while (stride <= highest && stride < MaximumStride)
+        {
+            stride *= 10;
+        }
+
+        return stride;
+    }
+
+    /// <summary>
+    /// Returns the number to publish for a channel.
+    /// </summary>
+    /// <param name="channel">The channel.</param>
+    /// <param name="stride">Stride from <see cref="ComputeStride"/>.</param>
+    /// <param name="byCategory">False returns the provider's own number unchanged.</param>
+    /// <returns>The channel number.</returns>
+    internal static int Resolve(LiveStreamInfo channel, int stride, bool byCategory)
+    {
+        if (!byCategory || channel.CategoryId is not int categoryId || categoryId < 0)
+        {
+            // A channel the provider files under no category has nothing to group by, so it keeps
+            // its own number and sorts among the low numbers.
+            return channel.Num;
+        }
+
+        long composite = ((long)categoryId * stride) + channel.Num;
+
+        // Providers have been seen with category ids in the thousands; combined with a widened
+        // stride that can leave the int range. Falling back to the raw number keeps such a channel
+        // working, at the cost of it sorting outside its category.
+        return composite > int.MaxValue ? channel.Num : (int)composite;
+    }
+}

--- a/Jellyfin.Xtream.Library/Service/FolderIdentity.cs
+++ b/Jellyfin.Xtream.Library/Service/FolderIdentity.cs
@@ -1,0 +1,64 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.RegularExpressions;
+
+namespace Jellyfin.Xtream.Library.Service;
+
+/// <summary>
+/// Reads the metadata ids back out of a folder name.
+/// <para>
+/// Folder names are the only record of an item's identity for a library synced before the snapshot
+/// started carrying it, so this is what backfills those items on the next sync (GitHub #88).
+/// </para>
+/// </summary>
+public static partial class FolderIdentity
+{
+    /// <summary>
+    /// Reads the TMDB id out of a folder name such as "Some Movie (2024) [tmdbid-1234]".
+    /// </summary>
+    /// <param name="folderName">Folder name to read.</param>
+    /// <param name="tmdbId">The id, when the name carries one.</param>
+    /// <returns>True when an id was found.</returns>
+    public static bool TryParseTmdbId(string? folderName, out int tmdbId)
+        => TryParse(TmdbIdPattern(), folderName, out tmdbId);
+
+    /// <summary>
+    /// Reads the TVDB id out of a folder name such as "Some Show [tvdbid-1234]".
+    /// </summary>
+    /// <param name="folderName">Folder name to read.</param>
+    /// <param name="tvdbId">The id, when the name carries one.</param>
+    /// <returns>True when an id was found.</returns>
+    public static bool TryParseTvdbId(string? folderName, out int tvdbId)
+        => TryParse(TvdbIdPattern(), folderName, out tvdbId);
+
+    private static bool TryParse(Regex pattern, string? folderName, out int id)
+    {
+        id = 0;
+        if (string.IsNullOrEmpty(folderName))
+        {
+            return false;
+        }
+
+        var match = pattern.Match(folderName);
+        return match.Success && int.TryParse(match.Groups[1].ValueSpan, out id);
+    }
+
+    [GeneratedRegex(@"\[tmdbid-(\d+)\]", RegexOptions.IgnoreCase)]
+    private static partial Regex TmdbIdPattern();
+
+    [GeneratedRegex(@"\[tvdbid-(\d+)\]", RegexOptions.IgnoreCase)]
+    private static partial Regex TvdbIdPattern();
+}

--- a/Jellyfin.Xtream.Library/Service/LiveTvService.cs
+++ b/Jellyfin.Xtream.Library/Service/LiveTvService.cs
@@ -844,7 +844,10 @@ public class LiveTvService : IDisposable
             ? channels.Where(c => c.TvArchive && c.TvArchiveDuration > 0).ToList()
             : channels;
 
-        foreach (var channel in filteredChannels.OrderBy(c => c.Num))
+        int stride = ChannelNumbering.ComputeStride(filteredChannels);
+        bool numberByCategory = config.LiveTvNumberByCategory;
+
+        foreach (var channel in filteredChannels.OrderBy(c => ChannelNumbering.Resolve(c, stride, numberByCategory)))
         {
             var cleanName = ChannelNameCleaner.CleanChannelName(
                 channel.Name,
@@ -857,7 +860,7 @@ public class LiveTvService : IDisposable
             extinf.Append("#EXTINF:-1");
             extinf.Append(CultureInfo.InvariantCulture, $" tvg-id=\"{EscapeAttribute(epgId)}\"");
             extinf.Append(CultureInfo.InvariantCulture, $" tvg-name=\"{EscapeAttribute(cleanName)}\"");
-            extinf.Append(CultureInfo.InvariantCulture, $" tvg-chno=\"{channel.Num}\"");
+            extinf.Append(CultureInfo.InvariantCulture, $" tvg-chno=\"{ChannelNumbering.Resolve(channel, stride, numberByCategory)}\"");
 
             var logoUrl = ChannelLogoResolver.ResolveDisplayUrl(channel.StreamIcon, channel.StreamId, baseUrl);
             if (!string.IsNullOrEmpty(logoUrl))
@@ -978,7 +981,10 @@ public class LiveTvService : IDisposable
         sb.AppendLine("<tv generator-info-name=\"Jellyfin Xtream Library\">");
 
         // Channel definitions
-        foreach (var channel in channels.OrderBy(c => c.Num))
+        int epgStride = ChannelNumbering.ComputeStride(channels);
+        bool epgNumberByCategory = config.LiveTvNumberByCategory;
+
+        foreach (var channel in channels.OrderBy(c => ChannelNumbering.Resolve(c, epgStride, epgNumberByCategory)))
         {
             var cleanName = ChannelNameCleaner.CleanChannelName(
                 channel.Name,

--- a/Jellyfin.Xtream.Library/Service/Models/ContentSnapshot.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/ContentSnapshot.cs
@@ -104,6 +104,16 @@ public class MovieSnapshot
     /// merge two items on.
     /// </summary>
     public ItemIdSource TmdbIdSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the stream whose title named the shared folder, when this item was grouped.
+    /// <para>
+    /// Recorded rather than worked out again later: which stream ends up owning a folder depends
+    /// on the order a run processed them, and a later run that recomputed a different owner would
+    /// hand the plain file name to a second stream and overwrite the first one's file.
+    /// </para>
+    /// </summary>
+    public int? GroupOwnerStreamId { get; set; }
 }
 
 /// <summary>

--- a/Jellyfin.Xtream.Library/Service/Models/ContentSnapshot.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/ContentSnapshot.cs
@@ -87,6 +87,23 @@ public class MovieSnapshot
     /// Gets or sets the MD5 checksum of key fields for change detection.
     /// </summary>
     public string Checksum { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the folder this stream was written to, without the library path.
+    /// Empty in a snapshot written before this was recorded (GitHub #88).
+    /// </summary>
+    public string FolderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the TMDB id the item resolved to, if any.
+    /// </summary>
+    public int? TmdbId { get; set; }
+
+    /// <summary>
+    /// Gets or sets where <see cref="TmdbId"/> came from. Only a provider-supplied id is safe to
+    /// merge two items on.
+    /// </summary>
+    public ItemIdSource TmdbIdSource { get; set; }
 }
 
 /// <summary>
@@ -128,6 +145,27 @@ public class SeriesSnapshot
     /// Gets or sets the MD5 checksum of key fields for change detection.
     /// </summary>
     public string Checksum { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the folder this series was written to, without the library path.
+    /// Empty in a snapshot written before this was recorded (GitHub #88).
+    /// </summary>
+    public string FolderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the TMDB id the series resolved to, if any.
+    /// </summary>
+    public int? TmdbId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TVDB id the series resolved to, if any. Series folders prefer TVDB.
+    /// </summary>
+    public int? TvdbId { get; set; }
+
+    /// <summary>
+    /// Gets or sets where the recorded id came from.
+    /// </summary>
+    public ItemIdSource IdSource { get; set; }
 }
 
 /// <summary>

--- a/Jellyfin.Xtream.Library/Service/Models/ItemIdentity.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/ItemIdentity.cs
@@ -49,4 +49,5 @@ public enum ItemIdSource
 /// <param name="TmdbId">Resolved TMDB id, if any.</param>
 /// <param name="TvdbId">Resolved TVDB id, if any. Series only.</param>
 /// <param name="Source">Where <paramref name="TmdbId"/> or <paramref name="TvdbId"/> came from.</param>
-public sealed record ItemIdentity(string FolderName, int? TmdbId, int? TvdbId, ItemIdSource Source);
+/// <param name="GroupOwnerStreamId">Stream whose title named the shared folder, when grouped.</param>
+public sealed record ItemIdentity(string FolderName, int? TmdbId, int? TvdbId, ItemIdSource Source, int? GroupOwnerStreamId = null);

--- a/Jellyfin.Xtream.Library/Service/Models/ItemIdentity.cs
+++ b/Jellyfin.Xtream.Library/Service/Models/ItemIdentity.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Library.Service.Models;
+
+/// <summary>
+/// Where the metadata id recorded for an item came from. The distinction matters for grouping
+/// (GitHub #88): only an id the provider itself supplied is safe to merge two items on. An id a
+/// name lookup guessed can be wrong in exactly the way that hurts, for example a live-action film
+/// and its animated remake sharing a title.
+/// </summary>
+public enum ItemIdSource
+{
+    /// <summary>No id was resolved.</summary>
+    None = 0,
+
+    /// <summary>The provider returned the id in its own metadata.</summary>
+    Provider = 1,
+
+    /// <summary>A name-based lookup guessed the id.</summary>
+    Lookup = 2,
+
+    /// <summary>The user pinned the id in the folder overrides.</summary>
+    Override = 3,
+
+    /// <summary>
+    /// The id was read back off an existing folder name. Where it originally came from is not
+    /// recoverable from disk, so it is treated as unproven until a sync resolves the item again.
+    /// </summary>
+    Unknown = 4,
+}
+
+/// <summary>
+/// What one provider stream resolved to on disk during a sync.
+/// </summary>
+/// <param name="FolderName">Folder the item was written to, without the library path.</param>
+/// <param name="TmdbId">Resolved TMDB id, if any.</param>
+/// <param name="TvdbId">Resolved TVDB id, if any. Series only.</param>
+/// <param name="Source">Where <paramref name="TmdbId"/> or <paramref name="TvdbId"/> came from.</param>
+public sealed record ItemIdentity(string FolderName, int? TmdbId, int? TvdbId, ItemIdSource Source);

--- a/Jellyfin.Xtream.Library/Service/SnapshotService.cs
+++ b/Jellyfin.Xtream.Library/Service/SnapshotService.cs
@@ -40,6 +40,20 @@ public class SnapshotService : IDisposable
     }
 
     /// <summary>
+    /// Builds the per-provider snapshot key, "{index}-{first 8 of the md5 of the base url}".
+    /// </summary>
+    /// <param name="providerIndex">Index of the provider in the configuration.</param>
+    /// <param name="baseUrl">Provider base URL.</param>
+    /// <returns>The key.</returns>
+#pragma warning disable CA5351 // the hash names a directory, it protects nothing
+    public static string BuildProviderKey(int providerIndex, string baseUrl)
+    {
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(baseUrl ?? string.Empty));
+        return $"{providerIndex}-{Convert.ToHexString(hash)[..8].ToLowerInvariant()}";
+    }
+#pragma warning restore CA5351
+
+    /// <summary>
     /// Gets the snapshot directory for the given provider key.
     /// Provider key format: "{providerIndex}-{urlHashPrefix}" (e.g. "0-a1b2c3d4").
     /// Use "0-legacy" for snapshots created before multi-provider support.

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -612,7 +612,7 @@ public partial class StrmSyncService
         // would refuse a legitimate write. Case-insensitively they are one file, and not folding
         // them would hand out two claims and let the second silently overwrite the first, which
         // is the exact bug this guard exists to stop.
-        var claimedStrmPaths = new ConcurrentDictionary<string, byte>(PathClaimComparer);
+        var claimedPaths = new ConcurrentDictionary<string, byte>(PathClaimComparer);
 
         // Check if sync is suppressed (e.g., after CleanLibraries)
         if (_syncSuppressed)
@@ -686,7 +686,7 @@ public partial class StrmSyncService
                     CurrentProgress.Phase = $"Provider {i + 1}/{enabledProviders.Count}: {provider.Name}";
                 }
 
-                var providerResult = await SyncProviderAsync(providerIndex, provider, claimedStrmPaths, linkedToken).ConfigureAwait(false);
+                var providerResult = await SyncProviderAsync(providerIndex, provider, claimedPaths, linkedToken).ConfigureAwait(false);
                 MergeResult(globalResult, providerResult);
             }
 
@@ -872,14 +872,16 @@ public partial class StrmSyncService
     /// </summary>
     /// <param name="providerIndex">Zero-based index of this provider in the Providers list.</param>
     /// <param name="provider">The provider configuration.</param>
-    /// <param name="claimedStrmPaths">STRM paths already written during this sync run, shared across providers.</param>
+    /// <param name="claimedPaths">File paths already written during this sync run, shared across providers.
+/// Covers STRM files and the NFO next to them: both are written from the parallel movie and episode
+/// loops, and both can be targeted by more than one stream (GitHub #80, #90).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The sync result for this provider.</returns>
 #pragma warning disable CA5351
     private async Task<SyncResult> SyncProviderAsync(
         int providerIndex,
         ProviderConfig provider,
-        ConcurrentDictionary<string, byte> claimedStrmPaths,
+        ConcurrentDictionary<string, byte> claimedPaths,
         CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTime.UtcNow };
@@ -890,22 +892,26 @@ public partial class StrmSyncService
         _client.RetryDelayMs = provider.RetryDelayMs;
         _client.Timeout = TimeSpan.FromSeconds(provider.TimeoutSeconds);
 
-        // Compute provider key for snapshot directory isolation: "{index}-{urlHash8}"
-        var urlHashBytes = MD5.HashData(Encoding.UTF8.GetBytes(provider.BaseUrl));
-        var providerKey = $"{providerIndex}-{Convert.ToHexString(urlHashBytes)[..8].ToLowerInvariant()}";
+        // Snapshot directory isolation. Shared with the regroup action, which has to find the
+        // same snapshot this sync wrote.
+        var providerKey = SnapshotService.BuildProviderKey(providerIndex, provider.BaseUrl);
 
         // Load previous snapshot for incremental sync
         ContentSnapshot? previousSnapshot = null;
         ContentSnapshot? hintSnapshot = null;
         bool isIncrementalSync = false;
 
-        if (provider.EnableIncrementalSync)
+        if (provider.EnableIncrementalSync || provider.GroupMoviesByTmdbId)
         {
             CurrentProgress.Phase = "Loading snapshot";
-            previousSnapshot = await _snapshotService.LoadLatestSnapshotAsync(providerKey, cancellationToken).ConfigureAwait(false);
+            var loadedSnapshot = await _snapshotService.LoadLatestSnapshotAsync(providerKey, cancellationToken).ConfigureAwait(false);
 
-            // Keep raw snapshot as hint for smart-skip optimization (even during full sync)
-            hintSnapshot = previousSnapshot;
+            // Keep raw snapshot as hint for smart-skip optimization (even during full sync). It is
+            // also the grouping map, which is why it is loaded even with incremental sync off: a
+            // full run that started from nothing would scatter a group that already exists on disk
+            // and then leave the old folder behind as an orphan (codex review).
+            hintSnapshot = loadedSnapshot;
+            previousSnapshot = provider.EnableIncrementalSync ? loadedSnapshot : null;
 
             if (previousSnapshot != null)
             {
@@ -1004,11 +1010,12 @@ public partial class StrmSyncService
                             provider,
                             moviesPath,
                             syncedFiles,
-                            claimedStrmPaths,
+                            claimedPaths,
                             result,
                             previousSnapshot,
                             allCollectedMovies,
                             movieIdentities,
+                            hintSnapshot,
                             cancellationToken).ConfigureAwait(false);
                     },
                     cancellationToken));
@@ -1023,7 +1030,7 @@ public partial class StrmSyncService
                         await SyncSeriesAsync(
                             provider,
                             seriesPath,
-                            claimedStrmPaths,
+                            claimedPaths,
                             syncedFiles,
                             result,
                             previousSnapshot,
@@ -1048,11 +1055,12 @@ public partial class StrmSyncService
                     provider,
                     moviesPath,
                     syncedFiles,
-                    claimedStrmPaths,
+                    claimedPaths,
                     result,
                     previousSnapshot,
                     allCollectedMovies,
                     movieIdentities,
+                    hintSnapshot,
                     cancellationToken).ConfigureAwait(false);
             }
 
@@ -1062,7 +1070,7 @@ public partial class StrmSyncService
                 await SyncSeriesAsync(
                     provider,
                     seriesPath,
-                    claimedStrmPaths,
+                    claimedPaths,
                     syncedFiles,
                     result,
                     previousSnapshot,
@@ -1238,11 +1246,13 @@ public partial class StrmSyncService
             }
         }
 
-        // Save snapshot for next incremental sync
-        if (provider.EnableIncrementalSync && !cancellationToken.IsCancellationRequested)
+        // Save snapshot for next incremental sync. Grouping needs it too: the snapshot is what
+        // records which folder each stream went to and whether the provider confirmed its id, and
+        // the regroup action has nothing to work from without it (GitHub #88).
+        if ((provider.EnableIncrementalSync || provider.GroupMoviesByTmdbId) && !cancellationToken.IsCancellationRequested)
         {
             CurrentProgress.Phase = "Saving snapshot";
-            await SaveSnapshotAsync(provider, providerKey, allCollectedMovies, allCollectedSeries, allSeriesInfoDict, movieIdentities, seriesIdentities, result.FailedItems, cancellationToken).ConfigureAwait(false);
+            await SaveSnapshotAsync(provider, providerKey, allCollectedMovies, allCollectedSeries, allSeriesInfoDict, movieIdentities, seriesIdentities, hintSnapshot, result.FailedItems, cancellationToken).ConfigureAwait(false);
         }
 
         result.WasIncrementalSync = isIncrementalSync;
@@ -1412,17 +1422,40 @@ public partial class StrmSyncService
         ProviderConfig provider,
         string moviesPath,
         ConcurrentDictionary<string, byte> syncedFiles,
-        ConcurrentDictionary<string, byte> claimedStrmPaths,
+        ConcurrentDictionary<string, byte> claimedPaths,
         SyncResult result,
         ContentSnapshot? previousSnapshot,
         ConcurrentBag<StreamInfo> allCollectedMovies,
         ConcurrentDictionary<int, ItemIdentity> movieIdentities,
+        ContentSnapshot? groupingHint,
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
         var globalConfig = Plugin.Instance.Configuration;
         var categories = await _client.GetVodCategoryAsync(connectionInfo, cancellationToken).ConfigureAwait(false);
         var processedStreamIds = new ConcurrentDictionary<int, bool>();
+
+        // GitHub #88. Folder each groupable TMDB id lives in. Seeded from the snapshot so the
+        // choice made on an earlier run keeps holding, then extended with ids first seen this run.
+        // Only new movies consult it: nothing already on disk is moved by a sync.
+        bool groupByTmdb = provider.GroupMoviesByTmdbId;
+
+        // Grouping keys on the id the provider returns in get_vod_info, so that call has to happen
+        // even when the name-based metadata lookup is off. Without this, turning grouping on with
+        // lookup off would silently do nothing.
+        bool needProviderTmdbId = globalConfig.EnableMetadataLookup || groupByTmdb;
+        // Keyed by TMDB id, holding the stream that named the folder. Ownership is tracked by
+        // stream id rather than by comparing names: two streams can share a title and a year, and
+        // comparing names would then make neither of them a guest, so both would claim the same
+        // file name and one would be refused (codex review).
+        var groupFolders = new ConcurrentDictionary<int, (int OwnerStreamId, string FolderName)>();
+        if (groupByTmdb)
+        {
+            foreach (var mapped in TmdbGrouping.BuildFolderMap(groupingHint))
+            {
+                groupFolders.TryAdd(mapped.Key, mapped.Value);
+            }
+        }
 
         // Parse folder mappings (category ID → folder names) - only in Multiple folder mode.
         // This has to come before the category filter, because in Multiple folder mode the
@@ -1721,20 +1754,27 @@ public partial class StrmSyncService
 
                     foreach (var targetFolder in targetFolders)
                     {
+                        string movieBasePath = string.IsNullOrEmpty(targetFolder)
+                            ? moviesPath
+                            : Path.Combine(moviesPath, targetFolder);
+
                         if (existingMovieFolders.TryGetValue(targetFolder, out var folderCache) &&
                             folderCache.TryGetValue(baseName, out var existingFolderName))
                         {
-                            string movieBasePath = string.IsNullOrEmpty(targetFolder)
-                                ? moviesPath
-                                : Path.Combine(moviesPath, targetFolder);
-                            string movieFolder = Path.Combine(movieBasePath, existingFolderName);
-                            if (Directory.Exists(movieFolder))
-                            {
-                                foreach (var strmFile in Directory.GetFiles(movieFolder, "*.strm"))
-                                {
-                                    syncedFiles.TryAdd(strmFile, 0);
-                                }
-                            }
+                            ProtectStrmFilesIn(Path.Combine(movieBasePath, existingFolderName), syncedFiles);
+                        }
+
+                        // A grouped guest sits in the folder its owner named, which is not keyed by
+                        // its own base name, so the lookup above cannot find it and cleanup would
+                        // delete a file the provider still lists. The snapshot remembers where the
+                        // file went (GitHub #88). Only the guest's own file is protected: marking
+                        // the whole shared folder would also keep a departed owner's file alive
+                        // forever (codex review).
+                        if (groupingHint != null
+                            && groupingHint.Movies.TryGetValue(m.Stream.StreamId, out var recordedMovie)
+                            && !string.IsNullOrEmpty(recordedMovie.FolderName))
+                        {
+                            ProtectGuestStrmIn(Path.Combine(movieBasePath, recordedMovie.FolderName), m.Stream.StreamId, syncedFiles);
                         }
                     }
                 }
@@ -1750,7 +1790,7 @@ public partial class StrmSyncService
             // Pre-fetch VOD info for new movies that need metadata lookup
             // This bulk phase is much faster than per-movie fetching during processing
             var vodInfoCache = new ConcurrentDictionary<int, VodInfoResponse?>();
-            if (enableMetadataLookup)
+            if (needProviderTmdbId)
             {
                 var moviesToPreFetch = batchMovies.Where(m =>
                 {
@@ -1762,15 +1802,21 @@ public partial class StrmSyncService
                         return false;
                     }
 
-                    // Check if folder already exists (no need to fetch VOD info)
-                    foreach (var targetFolder in m.CategoryIds.SelectMany(cid =>
-                        folderMappings.TryGetValue(cid, out var f) ? f : Enumerable.Empty<string>())
-                        .DefaultIfEmpty(string.Empty))
+                    // Folder already there means nothing left to look up, unless grouping is on:
+                    // the regroup action can only merge folders whose id the provider confirmed,
+                    // so those items have to be fetched too or the button has nothing to work with
+                    // and the "run a full sync first" advice would be a lie (GitHub #88).
+                    if (!groupByTmdb)
                     {
-                        if (existingMovieFolders.TryGetValue(targetFolder, out var fc) &&
-                            fc.ContainsKey(baseName))
+                        foreach (var targetFolder in m.CategoryIds.SelectMany(cid =>
+                            folderMappings.TryGetValue(cid, out var f) ? f : Enumerable.Empty<string>())
+                            .DefaultIfEmpty(string.Empty))
                         {
-                            return false;
+                            if (existingMovieFolders.TryGetValue(targetFolder, out var fc) &&
+                                fc.ContainsKey(baseName))
+                            {
+                                return false;
+                            }
                         }
                     }
 
@@ -1833,10 +1879,10 @@ public partial class StrmSyncService
                     {
                         try
                         {
-                            var detail = await _dispatcharrClient.GetMovieDetailAsync(connectionInfo.BaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
+                            var detail = await _dispatcharrClient.GetMovieDetailAsync(provider.EffectiveDispatcharrBaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
                             if (detail != null && !string.IsNullOrEmpty(detail.Uuid))
                             {
-                                var providers = await _dispatcharrClient.GetMovieProvidersAsync(connectionInfo.BaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
+                                var providers = await _dispatcharrClient.GetMovieProvidersAsync(provider.EffectiveDispatcharrBaseUrl, movieEntry.Stream.StreamId, ct).ConfigureAwait(false);
                                 if (providers.Count > 1)
                                 {
                                     // Deduplicate by stream_id
@@ -1866,6 +1912,43 @@ public partial class StrmSyncService
                     }).ConfigureAwait(false);
 
                 _logger.LogInformation("Found {Count} multi-provider movies in batch {Batch}/{Total}", dispatcharrCache.Count, batchIndex + 1, totalBatches);
+            }
+
+            if (groupByTmdb)
+            {
+                // Lowest stream id names the folder, so which of several titles wins does not
+                // depend on how the parallel loop below happened to schedule them.
+                foreach (var candidate in batchMovies.OrderBy(m => m.Stream.StreamId))
+                {
+                    string candidateName = SanitizeFileName(candidate.Stream.Name, provider.CustomTitleRemoveTerms);
+                    int? candidateYear = ExtractYear(candidate.Stream.Name);
+                    string candidateBaseName = candidateYear.HasValue ? $"{candidateName} ({candidateYear})" : candidateName;
+
+                    // An id pinned by hand groups exactly like one the provider gave, so it is
+                    // seeded here too. Ownership has to be settled before any file is written,
+                    // otherwise the owner recorded afterwards can disagree with the names on disk.
+                    int candidateTmdbId;
+                    if (tmdbOverrides.TryGetValue(candidateBaseName, out int pinnedCandidateId))
+                    {
+                        candidateTmdbId = pinnedCandidateId;
+                    }
+                    else if (!vodInfoCache.TryGetValue(candidate.Stream.StreamId, out var candidateInfo)
+                        || string.IsNullOrEmpty(candidateInfo?.Info?.TmdbId)
+                        || !int.TryParse(candidateInfo.Info.TmdbId, out candidateTmdbId))
+                    {
+                        continue;
+                    }
+
+                    if (!IsUsableMetadataId(candidateTmdbId))
+                    {
+                        continue;
+                    }
+
+                    groupFolders.TryAdd(
+                        candidateTmdbId,
+                        (candidate.Stream.StreamId,
+                         BuildMovieFolderName(candidateName, candidateYear, tmdbOverrides, candidateTmdbId, null)));
+                }
             }
 
             CurrentProgress.MoviePhase = $"Syncing Movies (batch {batchIndex + 1}/{totalBatches})";
@@ -1930,14 +2013,88 @@ public partial class StrmSyncService
                     int? autoLookupTmdbId = null;
                     string folderName;
 
+                    // True when this stream is a guest in a folder another title named. Its files
+                    // then carry the stream id, so which of the two gets renamed does not depend on
+                    // the order the parallel loop happened to run them in, and does not swap over
+                    // between syncs (GitHub #88).
+                    bool joinedGroupFolder = false;
+                    int? groupOwnerStreamId = null;
+
                     if (existingFolderName != null)
                     {
                         folderName = existingFolderName;
+
+                        // The folder stays exactly where it is: a sync never moves anything. What
+                        // this does is confirm the provider's id so the regroup action can later
+                        // merge this folder on the user's say-so (GitHub #88).
+                        if (groupByTmdb && !tmdbOverrides.ContainsKey(baseName))
+                        {
+                            if (!vodInfoCache.TryGetValue(stream.StreamId, out vodInfo))
+                            {
+                                try
+                                {
+                                    vodInfo = await _client.GetVodInfoAsync(connectionInfo, stream.StreamId, ct).ConfigureAwait(false);
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    throw;
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogDebug(ex, "Failed to confirm provider TMDB id for existing folder: {StreamId}", stream.StreamId);
+                                }
+                            }
+
+                            if (!string.IsNullOrEmpty(vodInfo?.Info?.TmdbId)
+                                && int.TryParse(vodInfo.Info.TmdbId, out int existingTmdbId)
+                                && IsUsableMetadataId(existingTmdbId))
+                            {
+                                providerTmdbId = existingTmdbId;
+                            }
+                        }
+
+                        // Two grouped streams can share a title, which means both find the same
+                        // folder here and neither would count as a guest, so both would build the
+                        // plain file name and one would be refused as a collision. Membership is
+                        // restored from the recorded owner so the guest keeps its own file name on
+                        // every later run (codex review).
+                        if (groupByTmdb)
+                        {
+                            int? existingGroupId = tmdbOverrides.TryGetValue(baseName, out int pinnedExistingId)
+                                ? pinnedExistingId
+                                : providerTmdbId;
+
+                            // The provider can simply fail to answer for a moment. Letting that
+                            // dissolve a group that already exists would put the guest back on the
+                            // plain file name, collide it with its owner, and downgrade its record
+                            // to unproven, after which cleanup could take its file. A group the
+                            // provider confirmed earlier stands until it says otherwise.
+                            if (!existingGroupId.HasValue
+                                && groupingHint != null
+                                && groupingHint.Movies.TryGetValue(stream.StreamId, out var recordedIdentity)
+                                && recordedIdentity.TmdbId.HasValue
+                                && TmdbGrouping.IsGroupable(recordedIdentity.TmdbIdSource))
+                            {
+                                existingGroupId = recordedIdentity.TmdbId;
+                                providerTmdbId = recordedIdentity.TmdbId;
+                            }
+
+                            if (existingGroupId.HasValue
+                                && IsUsableMetadataId(existingGroupId.Value)
+                                && groupFolders.TryGetValue(existingGroupId.Value, out var recordedGroup)
+                                && string.Equals(recordedGroup.FolderName, folderName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                joinedGroupFolder = recordedGroup.OwnerStreamId != stream.StreamId;
+                                groupOwnerStreamId = recordedGroup.OwnerStreamId;
+                            }
+                        }
                     }
                     else
                     {
-                        // New movie - get provider TMDB ID from pre-fetched cache
-                        if (enableMetadataLookup && !tmdbOverrides.ContainsKey(baseName))
+                        // New movie - get provider TMDB ID from pre-fetched cache. Gated on the
+                        // wider flag: the name lookup below still needs enableMetadataLookup, but
+                        // the provider's own id is also what grouping keys on.
+                        if (needProviderTmdbId && !tmdbOverrides.ContainsKey(baseName))
                         {
                             if (vodInfoCache.TryGetValue(stream.StreamId, out var cachedInfo))
                             {
@@ -1955,7 +2112,9 @@ public partial class StrmSyncService
                                 }
                             }
 
-                            if (!string.IsNullOrEmpty(vodInfo?.Info?.TmdbId) && int.TryParse(vodInfo.Info.TmdbId, out int tmdbParsed))
+                            if (!string.IsNullOrEmpty(vodInfo?.Info?.TmdbId)
+                                && int.TryParse(vodInfo.Info.TmdbId, out int tmdbParsed)
+                                && IsUsableMetadataId(tmdbParsed))
                             {
                                 providerTmdbId = tmdbParsed;
                             }
@@ -1984,6 +2143,20 @@ public partial class StrmSyncService
                         }
 
                         folderName = BuildMovieFolderName(movieName, year, tmdbOverrides, providerTmdbId, autoLookupTmdbId);
+
+                        // Group on an id the provider gave or the user pinned, never on one a name
+                        // lookup guessed: a lookup can hand a film and its remake the same id.
+                        int? groupableTmdbId = tmdbOverrides.TryGetValue(baseName, out int pinnedTmdbId)
+                            ? pinnedTmdbId
+                            : providerTmdbId;
+
+                        if (groupByTmdb && groupableTmdbId.HasValue && IsUsableMetadataId(groupableTmdbId.Value))
+                        {
+                            var group = groupFolders.GetOrAdd(groupableTmdbId.Value, (stream.StreamId, folderName));
+                            joinedGroupFolder = group.OwnerStreamId != stream.StreamId;
+                            groupOwnerStreamId = group.OwnerStreamId;
+                            folderName = group.FolderName;
+                        }
                     }
 
                     movieIdentities[stream.StreamId] = BuildMovieIdentity(
@@ -1992,7 +2165,7 @@ public partial class StrmSyncService
                         existingFolderName != null,
                         tmdbOverrides,
                         providerTmdbId,
-                        autoLookupTmdbId);
+                        autoLookupTmdbId) with { GroupOwnerStreamId = groupOwnerStreamId };
 
                     // Build STRM URLs and filenames — Dispatcharr multi-stream or standard single-stream
                     var strmEntries = new List<(string StreamUrl, string StrmFileName)>();
@@ -2034,8 +2207,6 @@ public partial class StrmSyncService
                         {
                         string strmPath = Path.Combine(movieFolder, strmFileName);
 
-                        syncedFiles.TryAdd(strmPath, 0);
-
                         // TryAdd fails when another stream in this run already wrote this exact
                         // path. The name is built from the folder name and the version label only,
                         // so two streams sharing a title and a quality tag produce the same one.
@@ -2043,7 +2214,22 @@ public partial class StrmSyncService
                         // File.Exists branch below compares content against a URL that embeds the
                         // stream id, so it can never match across two streams and always falls
                         // through to the overwrite. Refuse instead, and count it.
-                        if (!claimedStrmPaths.TryAdd(strmPath, 0))
+                        // A guest in someone else's folder takes its file name from that folder, so
+                        // it would collide with the title that named it. That is the feature working,
+                        // not a provider quirk: keep both and tell them apart by stream id. The
+                        // owner keeps the plain name, so neither file is renamed on a later sync.
+                        if (joinedGroupFolder)
+                        {
+                            string groupedName = $"{Path.GetFileNameWithoutExtension(strmFileName)} - {stream.StreamId}{Path.GetExtension(strmFileName)}";
+                            strmPath = Path.Combine(movieFolder, groupedName);
+                        }
+
+                        // Only now, once the final name is known. Protecting the pre-rename path
+                        // would mark the folder owner's file as still wanted by a guest, so a
+                        // departed owner's file would never be cleaned up (codex review).
+                        syncedFiles.TryAdd(strmPath, 0);
+
+                        if (!claimedPaths.TryAdd(strmPath, 0))
                         {
                             Interlocked.Increment(ref nameCollisions);
                             _logger.LogWarning(
@@ -2090,7 +2276,7 @@ public partial class StrmSyncService
                             // file. Keeping it after a failed create would refuse a later duplicate
                             // that might have succeeded, and the name would end up with no STRM at
                             // all. Hand it back and let the original handler count the error.
-                            claimedStrmPaths.TryRemove(strmPath, out _);
+                            claimedPaths.TryRemove(strmPath, out _);
                             throw;
                         }
 
@@ -2107,6 +2293,7 @@ public partial class StrmSyncService
                             VideoInfo? nfoVideo = null;
                             AudioInfo? nfoAudio = null;
                             int? nfoDurationSecs = null;
+                            bool vodInfoFetchFailed = false;
 
                             if (enableProactiveMediaInfo)
                             {
@@ -2123,33 +2310,91 @@ public partial class StrmSyncService
                                     nfoAudio = vodInfo?.Info?.Audio;
                                     nfoDurationSecs = vodInfo?.Info?.DurationSecs;
                                 }
+                                catch (OperationCanceledException)
+                                {
+                                    throw;
+                                }
                                 catch (Exception ex)
                                 {
-                                    _logger.LogDebug(ex, "Failed to fetch VOD info for NFO: {StreamId}", stream.StreamId);
+                                    // Debug hid this: the write below still went ahead, just without plot,
+                                    // genre, cast or artwork, and overwrote whatever a sibling version had
+                                    // already written (GitHub #90). It is a Warning because the NFO that
+                                    // results is measurably worse than the one the provider could give.
+                                    vodInfoFetchFailed = true;
+                                    _logger.LogWarning(ex, "Failed to fetch VOD info for NFO: {StreamId}", stream.StreamId);
                                 }
                             }
 
                             var nfoPath = Path.Combine(movieFolder, $"{folderName}.nfo");
-                            await NfoWriter.WriteMovieNfoAsync(
-                                nfoPath,
-                                movieName,
-                                nfoVideo,
-                                nfoAudio,
-                                nfoDurationSecs,
-                                effectiveTmdbId,
-                                year,
-                                ct,
-                                plot: vodInfo?.Info?.Plot,
-                                genre: vodInfo?.Info?.Genre,
-                                director: vodInfo?.Info?.Director,
-                                cast: vodInfo?.Info?.Cast,
-                                country: vodInfo?.Info?.Country,
-                                rating: vodInfo?.Info?.Rating,
-                                premiered: vodInfo?.Info?.ReleaseDate,
-                                youtubeTrailerId: vodInfo?.Info?.YoutubeTrailer,
-                                dateAdded: AddedDateParser.Parse(stream.Added),
-                                posterUrl: vodInfo?.Info?.MovieImage ?? stream.StreamIcon,
-                                backdropUrl: vodInfo?.Info?.BackdropPaths.FirstOrDefault()).ConfigureAwait(false);
+
+                            // Every version of a title (V1/V2/V3) resolves to the same folder and so to
+                            // this same NFO path, and they are processed concurrently. Two guards, both
+                            // from GitHub #90:
+                            //
+                            // A failed metadata fetch must not replace a good file. The write would
+                            // otherwise go ahead with plot, cast and artwork missing and win by being
+                            // last. This one also holds across runs, which the claim below cannot.
+                            if (vodInfoFetchFailed && File.Exists(nfoPath))
+                            {
+                                _logger.LogWarning(
+                                    "Keeping the existing NFO for {MovieName}: metadata fetch failed for stream {StreamId}, so writing would strip it",
+                                    baseName,
+                                    stream.StreamId);
+                            }
+                            else if (!claimedPaths.TryAdd(nfoPath, 0))
+                            {
+                                // A sibling version already wrote it in this run. NfoWriter truncates and
+                                // rewrites, so letting both through interleaves them into a short file.
+                                _logger.LogDebug(
+                                    "NFO {NfoPath} already written by another stream in this run; stream {StreamId} skips it",
+                                    nfoPath,
+                                    stream.StreamId);
+                            }
+                            else
+                            {
+                                bool nfoWritten;
+                                try
+                                {
+                                    nfoWritten = await NfoWriter.WriteMovieNfoAsync(
+                                    nfoPath,
+                                    movieName,
+                                    nfoVideo,
+                                    nfoAudio,
+                                    nfoDurationSecs,
+                                    effectiveTmdbId,
+                                    year,
+                                    ct,
+                                    plot: vodInfo?.Info?.Plot,
+                                    genre: vodInfo?.Info?.Genre,
+                                    director: vodInfo?.Info?.Director,
+                                    cast: vodInfo?.Info?.Cast,
+                                    country: vodInfo?.Info?.Country,
+                                    rating: vodInfo?.Info?.Rating,
+                                    premiered: vodInfo?.Info?.ReleaseDate,
+                                    youtubeTrailerId: vodInfo?.Info?.YoutubeTrailer,
+                                    dateAdded: AddedDateParser.Parse(stream.Added),
+                                    posterUrl: vodInfo?.Info?.MovieImage ?? stream.StreamIcon,
+                                    backdropUrl: vodInfo?.Info?.BackdropPaths.FirstOrDefault()).ConfigureAwait(false);
+                                }
+                                catch
+                                {
+                                    // Same reasoning as the STRM claim: a claim is only worth holding
+                                    // once the file exists, otherwise a later version that could have
+                                    // succeeded is refused and the folder ends up with no NFO at all.
+                                    claimedPaths.TryRemove(nfoPath, out _);
+                                    throw;
+                                }
+
+                                if (vodInfoFetchFailed || !nfoWritten)
+                                {
+                                    // Either this stream had nothing to write, or NfoWriter decided
+                                    // there was not enough data to be worth a file. Holding the claim
+                                    // would make the outcome depend on which version happened to run
+                                    // first; releasing it lets a sibling with real metadata write,
+                                    // while the File.Exists guard above stops the reverse.
+                                    claimedPaths.TryRemove(nfoPath, out _);
+                                }
+                            }
                         }
 
                         // Download artwork for unmatched movies (only for first target folder)
@@ -2253,7 +2498,7 @@ public partial class StrmSyncService
     private async Task SyncSeriesAsync(
         ProviderConfig provider,
         string seriesPath,
-        ConcurrentDictionary<string, byte> claimedStrmPaths,
+        ConcurrentDictionary<string, byte> claimedPaths,
         ConcurrentDictionary<string, byte> syncedFiles,
         SyncResult result,
         ContentSnapshot? previousSnapshot,
@@ -3030,7 +3275,7 @@ public partial class StrmSyncService
                                 // File.Exists branch below cannot tell them apart, because it
                                 // compares against a URL carrying the episode id, so it would
                                 // silently overwrite. Refuse and count instead.
-                                if (!claimedStrmPaths.TryAdd(strmPath, 0))
+                                if (!claimedPaths.TryAdd(strmPath, 0))
                                 {
                                     Interlocked.Increment(ref episodeNameCollisions);
 
@@ -3085,7 +3330,7 @@ public partial class StrmSyncService
                                     // See the movie path: a claim is only worth holding once the
                                     // file exists, otherwise a later duplicate that could have
                                     // succeeded is refused and the name gets no STRM at all.
-                                    claimedStrmPaths.TryRemove(strmPath, out _);
+                                    claimedPaths.TryRemove(strmPath, out _);
                                     throw;
                                 }
 
@@ -3794,23 +4039,25 @@ public partial class StrmSyncService
         int? providerTmdbId,
         int? autoLookupTmdbId)
     {
-        if (fromExistingFolder)
-        {
-            // The folder is the only record left, and it does not say where its id came from.
-            // That matters: grouping may only merge ids the provider supplied, never ones a name
-            // lookup guessed, so this stays unproven until a sync resolves the item again.
-            int? diskTmdbId = FolderIdentity.TryParseTmdbId(folderName, out int parsedTmdbId) ? parsedTmdbId : null;
-            return new ItemIdentity(folderName, diskTmdbId, null, ItemIdSource.Unknown);
-        }
-
         if (overrides.TryGetValue(baseName, out int overrideTmdbId))
         {
             return new ItemIdentity(folderName, overrideTmdbId, null, ItemIdSource.Override);
         }
 
+        // Ahead of the folder-name fallback on purpose: an item already on disk whose id the
+        // provider confirmed this run is proven, and refusing to say so is what would leave the
+        // regroup action with nothing to merge.
         if (providerTmdbId.HasValue)
         {
             return new ItemIdentity(folderName, providerTmdbId, null, ItemIdSource.Provider);
+        }
+
+        if (fromExistingFolder)
+        {
+            // Nothing confirmed it this run, so the folder name is all there is, and it does not
+            // say where its id came from. Unproven until a sync resolves the item again.
+            int? diskTmdbId = FolderIdentity.TryParseTmdbId(folderName, out int parsedTmdbId) ? parsedTmdbId : null;
+            return new ItemIdentity(folderName, diskTmdbId, null, ItemIdSource.Unknown);
         }
 
         if (autoLookupTmdbId.HasValue)
@@ -3854,6 +4101,110 @@ public partial class StrmSyncService
 
         return new ItemIdentity(folderName, null, null, ItemIdSource.None);
     }
+
+    /// <summary>
+    /// Marks one grouped stream's own STRM as still wanted. Its file carries the stream id, so the
+    /// files its folder-mates own are deliberately left to answer for themselves.
+    /// </summary>
+    /// <param name="folder">Shared folder to look in. Missing folders are ignored.</param>
+    /// <param name="streamId">The stream whose file should survive cleanup.</param>
+    /// <param name="syncedFiles">The run's set of files that must survive cleanup.</param>
+    private static void ProtectGuestStrmIn(string folder, int streamId, ConcurrentDictionary<string, byte> syncedFiles)
+    {
+        if (!Directory.Exists(folder))
+        {
+            return;
+        }
+
+        string suffix = $" - {streamId}.strm";
+        foreach (var strmFile in Directory.GetFiles(folder, "*.strm"))
+        {
+            if (Path.GetFileName(strmFile).EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                syncedFiles.TryAdd(strmFile, 0);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Marks every STRM in a folder as still wanted, so orphan cleanup leaves it alone.
+    /// </summary>
+    /// <param name="folder">Folder to protect. Missing folders are ignored.</param>
+    /// <param name="syncedFiles">The run's set of files that must survive cleanup.</param>
+    private static void ProtectStrmFilesIn(string folder, ConcurrentDictionary<string, byte> syncedFiles)
+    {
+        if (!Directory.Exists(folder))
+        {
+            return;
+        }
+
+        foreach (var strmFile in Directory.GetFiles(folder, "*.strm"))
+        {
+            syncedFiles.TryAdd(strmFile, 0);
+        }
+    }
+
+    /// <summary>
+    /// What to record for a movie: what this run worked out, or what the last run recorded when
+    /// this run never looked at the item (GitHub #88).
+    /// </summary>
+    /// <param name="identities">Identities resolved during this run.</param>
+    /// <param name="previousSnapshot">Snapshot from the previous run, may be null.</param>
+    /// <param name="streamId">Stream to look up.</param>
+    /// <returns>Folder, id and where the id came from.</returns>
+    internal static (string FolderName, int? TmdbId, ItemIdSource Source, int? GroupOwnerStreamId) EffectiveMovieIdentity(
+        ConcurrentDictionary<int, ItemIdentity> identities,
+        ContentSnapshot? previousSnapshot,
+        int streamId)
+    {
+        // A stream this run handled wins outright, including when it resolved to no id: that is a
+        // fresh answer, not a missing one.
+        if (identities.TryGetValue(streamId, out var identity))
+        {
+            return (identity.FolderName, identity.TmdbId, identity.Source, identity.GroupOwnerStreamId);
+        }
+
+        if (previousSnapshot != null && previousSnapshot.Movies.TryGetValue(streamId, out var earlier))
+        {
+            return (earlier.FolderName, earlier.TmdbId, earlier.TmdbIdSource, earlier.GroupOwnerStreamId);
+        }
+
+        return (string.Empty, null, ItemIdSource.None, null);
+    }
+
+    /// <summary>
+    /// The series equivalent of <see cref="EffectiveMovieIdentity"/>.
+    /// </summary>
+    /// <param name="identities">Identities resolved during this run.</param>
+    /// <param name="previousSnapshot">Snapshot from the previous run, may be null.</param>
+    /// <param name="seriesId">Series to look up.</param>
+    /// <returns>Folder, ids and where they came from.</returns>
+    internal static (string FolderName, int? TmdbId, int? TvdbId, ItemIdSource Source) EffectiveSeriesIdentity(
+        ConcurrentDictionary<int, ItemIdentity> identities,
+        ContentSnapshot? previousSnapshot,
+        int seriesId)
+    {
+        if (identities.TryGetValue(seriesId, out var identity))
+        {
+            return (identity.FolderName, identity.TmdbId, identity.TvdbId, identity.Source);
+        }
+
+        if (previousSnapshot != null && previousSnapshot.Series.TryGetValue(seriesId, out var earlier))
+        {
+            return (earlier.FolderName, earlier.TmdbId, earlier.TvdbId, earlier.IdSource);
+        }
+
+        return (string.Empty, null, null, ItemIdSource.None);
+    }
+
+    /// <summary>
+    /// Whether a metadata id is worth acting on. Providers routinely send 0 for "no id", and a
+    /// grouping feature that treats 0 as an id would put every such film in one folder and then
+    /// offer that folder for an irreversible merge (GitHub #88).
+    /// </summary>
+    /// <param name="id">The id as the provider reported it.</param>
+    /// <returns>True when the id identifies something.</returns>
+    internal static bool IsUsableMetadataId(int id) => id > 0;
 
     /// <summary>
     /// Builds a movie folder name, optionally with TMDb ID suffix.
@@ -4143,6 +4494,7 @@ public partial class StrmSyncService
         ConcurrentDictionary<int, SeriesStreamInfo> seriesInfoDict,
         ConcurrentDictionary<int, ItemIdentity> movieIdentities,
         ConcurrentDictionary<int, ItemIdentity> seriesIdentities,
+        ContentSnapshot? carryForwardFrom,
         IReadOnlyList<FailedItem> failedItems,
         CancellationToken cancellationToken)
     {
@@ -4160,12 +4512,31 @@ public partial class StrmSyncService
                 ConfigFingerprint = SnapshotService.CalculateConfigFingerprint(provider, Plugin.Instance.Configuration.EnableMetadataLookup)
             };
 
+            // Movies were not synced this run, so allMovies is empty and rebuilding from it would
+            // drop every identity the previous run recorded, taking the grouping map with it.
+            if (!provider.SyncMovies && carryForwardFrom != null)
+            {
+                foreach (var carried in carryForwardFrom.Movies)
+                {
+                    snapshot.Movies[carried.Key] = carried.Value;
+                }
+            }
+
+            if (!provider.SyncSeries && carryForwardFrom != null)
+            {
+                foreach (var carried in carryForwardFrom.Series)
+                {
+                    snapshot.Series[carried.Key] = carried.Value;
+                }
+            }
+
             // Build movie snapshots
             var processedMovieIds = new HashSet<int>();
             foreach (var movie in allMovies)
             {
                 if (processedMovieIds.Add(movie.StreamId) && !failedMovieIds.Contains(movie.StreamId))
                 {
+                    var movieIdentity = EffectiveMovieIdentity(movieIdentities, carryForwardFrom, movie.StreamId);
                     snapshot.Movies[movie.StreamId] = new MovieSnapshot
                     {
                         StreamId = movie.StreamId,
@@ -4175,11 +4546,17 @@ public partial class StrmSyncService
                         CategoryId = movie.CategoryId ?? 0,
                         Added = movie.Added,
                         Checksum = SnapshotService.CalculateChecksum(movie),
-                        FolderName = movieIdentities.TryGetValue(movie.StreamId, out var movieIdentity)
-                            ? movieIdentity.FolderName
-                            : string.Empty,
-                        TmdbId = movieIdentity?.TmdbId,
-                        TmdbIdSource = movieIdentity?.Source ?? ItemIdSource.None
+
+                        // An incremental run never reaches the loop for an unchanged movie, so it
+                        // has no identity to record. Writing empty here would erase what an earlier
+                        // run worked out, and one scheduled sync would silently make regrouping
+                        // impossible (GitHub #88). Carry the previous record forward instead. A
+                        // stream the loop DID handle wins outright, including when it resolved to
+                        // no id at all, because that is a fresh answer rather than a missing one.
+                        FolderName = movieIdentity.FolderName,
+                        TmdbId = movieIdentity.TmdbId,
+                        TmdbIdSource = movieIdentity.Source,
+                        GroupOwnerStreamId = movieIdentity.GroupOwnerStreamId
                     };
                 }
             }
@@ -4196,6 +4573,7 @@ public partial class StrmSyncService
                         episodeCount = info.Episodes.Values.Sum(eps => eps.Count);
                     }
 
+                    var seriesIdentity = EffectiveSeriesIdentity(seriesIdentities, carryForwardFrom, series.SeriesId);
                     snapshot.Series[series.SeriesId] = new SeriesSnapshot
                     {
                         SeriesId = series.SeriesId,
@@ -4205,12 +4583,12 @@ public partial class StrmSyncService
                         EpisodeCount = episodeCount,
                         LastModified = series.LastModified.GetValueOrDefault(),
                         Checksum = SnapshotService.CalculateChecksum(series, episodeCount),
-                        FolderName = seriesIdentities.TryGetValue(series.SeriesId, out var seriesIdentity)
-                            ? seriesIdentity.FolderName
-                            : string.Empty,
-                        TmdbId = seriesIdentity?.TmdbId,
-                        TvdbId = seriesIdentity?.TvdbId,
-                        IdSource = seriesIdentity?.Source ?? ItemIdSource.None
+
+                        // Same carry-forward as movies: a skipped series has no identity this run.
+                        FolderName = seriesIdentity.FolderName,
+                        TmdbId = seriesIdentity.TmdbId,
+                        TvdbId = seriesIdentity.TvdbId,
+                        IdSource = seriesIdentity.Source
                     };
                 }
             }

--- a/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
+++ b/Jellyfin.Xtream.Library/Service/StrmSyncService.cs
@@ -957,6 +957,12 @@ public partial class StrmSyncService
         var allCollectedSeries = new ConcurrentBag<Series>();
         var allSeriesInfoDict = new ConcurrentDictionary<int, SeriesStreamInfo>();
 
+        // What each stream resolved to on disk this run (GitHub #88). Recorded into the snapshot at
+        // the end so a later sync can group by metadata id without re-deriving it from folder names.
+        // Nothing reads it yet.
+        var movieIdentities = new ConcurrentDictionary<int, ItemIdentity>();
+        var seriesIdentities = new ConcurrentDictionary<int, ItemIdentity>();
+
         // Ensure base directories exist
         string moviesPath = Path.Combine(provider.LibraryPath, "Movies");
         string seriesPath = Path.Combine(provider.LibraryPath, "Series");
@@ -1002,6 +1008,7 @@ public partial class StrmSyncService
                             result,
                             previousSnapshot,
                             allCollectedMovies,
+                            movieIdentities,
                             cancellationToken).ConfigureAwait(false);
                     },
                     cancellationToken));
@@ -1023,6 +1030,7 @@ public partial class StrmSyncService
                             hintSnapshot,
                             allCollectedSeries,
                             allSeriesInfoDict,
+                            seriesIdentities,
                             cancellationToken).ConfigureAwait(false);
                     },
                     cancellationToken));
@@ -1044,6 +1052,7 @@ public partial class StrmSyncService
                     result,
                     previousSnapshot,
                     allCollectedMovies,
+                    movieIdentities,
                     cancellationToken).ConfigureAwait(false);
             }
 
@@ -1060,6 +1069,7 @@ public partial class StrmSyncService
                     hintSnapshot,
                     allCollectedSeries,
                     allSeriesInfoDict,
+                    seriesIdentities,
                     cancellationToken).ConfigureAwait(false);
             }
         }
@@ -1232,7 +1242,7 @@ public partial class StrmSyncService
         if (provider.EnableIncrementalSync && !cancellationToken.IsCancellationRequested)
         {
             CurrentProgress.Phase = "Saving snapshot";
-            await SaveSnapshotAsync(provider, providerKey, allCollectedMovies, allCollectedSeries, allSeriesInfoDict, result.FailedItems, cancellationToken).ConfigureAwait(false);
+            await SaveSnapshotAsync(provider, providerKey, allCollectedMovies, allCollectedSeries, allSeriesInfoDict, movieIdentities, seriesIdentities, result.FailedItems, cancellationToken).ConfigureAwait(false);
         }
 
         result.WasIncrementalSync = isIncrementalSync;
@@ -1406,6 +1416,7 @@ public partial class StrmSyncService
         SyncResult result,
         ContentSnapshot? previousSnapshot,
         ConcurrentBag<StreamInfo> allCollectedMovies,
+        ConcurrentDictionary<int, ItemIdentity> movieIdentities,
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
@@ -1975,6 +1986,14 @@ public partial class StrmSyncService
                         folderName = BuildMovieFolderName(movieName, year, tmdbOverrides, providerTmdbId, autoLookupTmdbId);
                     }
 
+                    movieIdentities[stream.StreamId] = BuildMovieIdentity(
+                        folderName,
+                        baseName,
+                        existingFolderName != null,
+                        tmdbOverrides,
+                        providerTmdbId,
+                        autoLookupTmdbId);
+
                     // Build STRM URLs and filenames — Dispatcharr multi-stream or standard single-stream
                     var strmEntries = new List<(string StreamUrl, string StrmFileName)>();
                     if (enableDispatcharrMode &&
@@ -2241,6 +2260,7 @@ public partial class StrmSyncService
         ContentSnapshot? hintSnapshot,
         ConcurrentBag<Series> allCollectedSeries,
         ConcurrentDictionary<int, SeriesStreamInfo> allSeriesInfoDict,
+        ConcurrentDictionary<int, ItemIdentity> seriesIdentities,
         CancellationToken cancellationToken)
     {
         var connectionInfo = new ConnectionInfo(provider.BaseUrl, provider.Username, provider.Password);
@@ -2847,6 +2867,13 @@ public partial class StrmSyncService
                     }
 
                     string seriesFolderName = BuildSeriesFolderName(seriesName, year, tvdbOverrides, providerTmdbId, autoLookupTvdbId);
+
+                    seriesIdentities[series.SeriesId] = BuildSeriesIdentity(
+                        seriesFolderName,
+                        baseName,
+                        tvdbOverrides,
+                        providerTmdbId,
+                        autoLookupTvdbId);
 
                     // Determine target folders based on category mappings
                     var targetFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -3750,6 +3777,85 @@ public partial class StrmSyncService
     }
 
     /// <summary>
+    /// Records what a movie stream resolved to, and how trustworthy the id behind it is.
+    /// </summary>
+    /// <param name="folderName">Folder the movie was written to.</param>
+    /// <param name="baseName">Title and year, the key the overrides are stored under.</param>
+    /// <param name="fromExistingFolder">True when the name was reused from a folder already on disk.</param>
+    /// <param name="overrides">Manual TMDB overrides.</param>
+    /// <param name="providerTmdbId">TMDB id the provider itself returned.</param>
+    /// <param name="autoLookupTmdbId">TMDB id a name lookup guessed.</param>
+    /// <returns>The identity to record for this stream.</returns>
+    internal static ItemIdentity BuildMovieIdentity(
+        string folderName,
+        string baseName,
+        bool fromExistingFolder,
+        Dictionary<string, int> overrides,
+        int? providerTmdbId,
+        int? autoLookupTmdbId)
+    {
+        if (fromExistingFolder)
+        {
+            // The folder is the only record left, and it does not say where its id came from.
+            // That matters: grouping may only merge ids the provider supplied, never ones a name
+            // lookup guessed, so this stays unproven until a sync resolves the item again.
+            int? diskTmdbId = FolderIdentity.TryParseTmdbId(folderName, out int parsedTmdbId) ? parsedTmdbId : null;
+            return new ItemIdentity(folderName, diskTmdbId, null, ItemIdSource.Unknown);
+        }
+
+        if (overrides.TryGetValue(baseName, out int overrideTmdbId))
+        {
+            return new ItemIdentity(folderName, overrideTmdbId, null, ItemIdSource.Override);
+        }
+
+        if (providerTmdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, providerTmdbId, null, ItemIdSource.Provider);
+        }
+
+        if (autoLookupTmdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, autoLookupTmdbId, null, ItemIdSource.Lookup);
+        }
+
+        return new ItemIdentity(folderName, null, null, ItemIdSource.None);
+    }
+
+    /// <summary>
+    /// Records what a series resolved to. Series folders prefer TVDB, so both ids are kept.
+    /// </summary>
+    /// <param name="folderName">Folder the series was written to.</param>
+    /// <param name="baseName">Title and year, the key the overrides are stored under.</param>
+    /// <param name="overrides">Manual TVDB overrides.</param>
+    /// <param name="providerTmdbId">TMDB id the provider itself returned.</param>
+    /// <param name="autoLookupTvdbId">TVDB id a name lookup guessed.</param>
+    /// <returns>The identity to record for this series.</returns>
+    internal static ItemIdentity BuildSeriesIdentity(
+        string folderName,
+        string baseName,
+        Dictionary<string, int> overrides,
+        int? providerTmdbId,
+        int? autoLookupTvdbId)
+    {
+        if (overrides.TryGetValue(baseName, out int overrideTvdbId))
+        {
+            return new ItemIdentity(folderName, null, overrideTvdbId, ItemIdSource.Override);
+        }
+
+        if (providerTmdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, providerTmdbId, null, ItemIdSource.Provider);
+        }
+
+        if (autoLookupTvdbId.HasValue)
+        {
+            return new ItemIdentity(folderName, null, autoLookupTvdbId, ItemIdSource.Lookup);
+        }
+
+        return new ItemIdentity(folderName, null, null, ItemIdSource.None);
+    }
+
+    /// <summary>
     /// Builds a movie folder name, optionally with TMDb ID suffix.
     /// </summary>
     /// <param name="sanitizedName">The sanitized movie name.</param>
@@ -4035,6 +4141,8 @@ public partial class StrmSyncService
         ConcurrentBag<StreamInfo> allMovies,
         ConcurrentBag<Series> allSeries,
         ConcurrentDictionary<int, SeriesStreamInfo> seriesInfoDict,
+        ConcurrentDictionary<int, ItemIdentity> movieIdentities,
+        ConcurrentDictionary<int, ItemIdentity> seriesIdentities,
         IReadOnlyList<FailedItem> failedItems,
         CancellationToken cancellationToken)
     {
@@ -4066,7 +4174,12 @@ public partial class StrmSyncService
                         ContainerExtension = movie.ContainerExtension,
                         CategoryId = movie.CategoryId ?? 0,
                         Added = movie.Added,
-                        Checksum = SnapshotService.CalculateChecksum(movie)
+                        Checksum = SnapshotService.CalculateChecksum(movie),
+                        FolderName = movieIdentities.TryGetValue(movie.StreamId, out var movieIdentity)
+                            ? movieIdentity.FolderName
+                            : string.Empty,
+                        TmdbId = movieIdentity?.TmdbId,
+                        TmdbIdSource = movieIdentity?.Source ?? ItemIdSource.None
                     };
                 }
             }
@@ -4091,7 +4204,13 @@ public partial class StrmSyncService
                         CategoryId = series.CategoryId ?? 0,
                         EpisodeCount = episodeCount,
                         LastModified = series.LastModified.GetValueOrDefault(),
-                        Checksum = SnapshotService.CalculateChecksum(series, episodeCount)
+                        Checksum = SnapshotService.CalculateChecksum(series, episodeCount),
+                        FolderName = seriesIdentities.TryGetValue(series.SeriesId, out var seriesIdentity)
+                            ? seriesIdentity.FolderName
+                            : string.Empty,
+                        TmdbId = seriesIdentity?.TmdbId,
+                        TvdbId = seriesIdentity?.TvdbId,
+                        IdSource = seriesIdentity?.Source ?? ItemIdSource.None
                     };
                 }
             }

--- a/Jellyfin.Xtream.Library/Service/TmdbGrouping.cs
+++ b/Jellyfin.Xtream.Library/Service/TmdbGrouping.cs
@@ -1,0 +1,82 @@
+// Copyright (C) 2024  Roland Breitschaft
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Xtream.Library.Service.Models;
+
+namespace Jellyfin.Xtream.Library.Service;
+
+/// <summary>
+/// Works out which movie folders hold the same film.
+/// </summary>
+public static class TmdbGrouping
+{
+    /// <summary>
+    /// Whether an id from this source may be merged on.
+    /// <para>
+    /// Only what the provider itself returned, or what the user pinned by hand. An id a name
+    /// lookup guessed is refused, because a lookup can give a film and its remake the same id and
+    /// merging those is not undoable. An id read back off a folder name is refused for the same
+    /// reason: the name does not record where it came from.
+    /// </para>
+    /// </summary>
+    /// <param name="source">Where the id came from.</param>
+    /// <returns>True when the id may be grouped on.</returns>
+    public static bool IsGroupable(ItemIdSource source)
+        => source is ItemIdSource.Provider or ItemIdSource.Override;
+
+    /// <summary>
+    /// The folder each groupable TMDB id should live in, according to what the snapshot recorded.
+    /// <para>
+    /// The lowest stream id in a group decides the name, so the choice does not depend on the
+    /// order a sync happened to process things in, and does not move again on the next run.
+    /// </para>
+    /// </summary>
+    /// <param name="snapshot">Snapshot to read, may be null.</param>
+    /// <returns>TMDB id to the owning stream and its folder.</returns>
+    public static Dictionary<int, (int OwnerStreamId, string FolderName)> BuildFolderMap(ContentSnapshot? snapshot)
+    {
+        var map = new Dictionary<int, (int OwnerStreamId, string FolderName)>();
+        if (snapshot == null)
+        {
+            return map;
+        }
+
+        foreach (var group in GroupableMovies(snapshot).GroupBy(m => m.TmdbId!.Value))
+        {
+            // Prefer what the run that created this group actually did. Recomputing a winner
+            // here can disagree with the file names already on disk, and the disagreement shows up
+            // as one stream overwriting another's STRM on the next run.
+            var recorded = group.FirstOrDefault(m => m.GroupOwnerStreamId.HasValue);
+            if (recorded != null)
+            {
+                map[group.Key] = (recorded.GroupOwnerStreamId!.Value, recorded.FolderName);
+                continue;
+            }
+
+            var winner = group.OrderBy(m => m.StreamId).First();
+            map[group.Key] = (winner.StreamId, winner.FolderName);
+        }
+
+        return map;
+    }
+
+    private static IEnumerable<MovieSnapshot> GroupableMovies(ContentSnapshot snapshot)
+        => snapshot.Movies.Values.Where(m =>
+            m.TmdbId.HasValue
+            && IsGroupable(m.TmdbIdSource)
+            && !string.IsNullOrEmpty(m.FolderName));
+}

--- a/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
+++ b/Jellyfin.Xtream.Library/Service/XtreamTunerHost.cs
@@ -57,6 +57,7 @@ public class XtreamTunerHost : ITunerHost
     private volatile Dictionary<string, StreamStatsInfo> _streamStats = new();
     private List<ChannelInfo>? _cachedChannels;
     private DateTime _cacheTime = DateTime.MinValue;
+    private bool _cachedNumberByCategory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XtreamTunerHost"/> class.
@@ -94,7 +95,12 @@ public class XtreamTunerHost : ITunerHost
         }
 
         // Return cached channels if available and not expired
-        if (enableCache && _cachedChannels != null && DateTime.UtcNow - _cacheTime < CacheDuration)
+        // The numbering flag is part of the cache identity: flipping it changes every number, and
+        // serving the previous list would leave the numbers and the resolver map disagreeing.
+        if (enableCache
+            && _cachedChannels != null
+            && _cachedNumberByCategory == config.LiveTvNumberByCategory
+            && DateTime.UtcNow - _cacheTime < CacheDuration)
         {
             _logger.LogDebug("Returning cached channel list ({Count} channels)", _cachedChannels.Count);
             return _cachedChannels;
@@ -105,6 +111,7 @@ public class XtreamTunerHost : ITunerHost
         var channels = await _liveTvService.GetFilteredChannelsAsync(cancellationToken).ConfigureAwait(false);
         var categoryNames = await _liveTvService.GetCategoryNameMapAsync(cancellationToken).ConfigureAwait(false);
 
+        int stride = ChannelNumbering.ComputeStride(channels);
         var newMap = new Dictionary<string, string>(channels.Count);
         var newStats = new Dictionary<string, StreamStatsInfo>(channels.Count);
         int statsCount = 0;
@@ -112,7 +119,9 @@ public class XtreamTunerHost : ITunerHost
         var result = new List<ChannelInfo>(channels.Count);
         foreach (var channel in channels)
         {
-            var channelNumber = channel.Num.ToString(CultureInfo.InvariantCulture);
+            var channelNumber = ChannelNumbering
+                .Resolve(channel, stride, config.LiveTvNumberByCategory)
+                .ToString(CultureInfo.InvariantCulture);
             var channelId = BuildChannelId(channel.ProviderIndex, channel.StreamId);
 
             if (!newMap.TryAdd(channelNumber, channelId))
@@ -155,6 +164,7 @@ public class XtreamTunerHost : ITunerHost
         _streamStats = newStats;
         _cachedChannels = result;
         _cacheTime = DateTime.UtcNow;
+        _cachedNumberByCategory = config.LiveTvNumberByCategory;
         _logger.LogInformation("Channel list cached with {Count} channels ({StatsCount} with stream stats)", result.Count, statsCount);
 
         return result;


### PR DESCRIPTION
Brings the second half of #88 onto main.

#96 was opened against the part 1 branch so its diff stayed readable, and it merged there rather than here once part 1 landed. This carries the same content the rest of the way. The review history, the six passes and what each of them changed, is on #96.

What lands: `GroupMoviesByTmdbId`, off by default, per provider. Movies the provider reports under the same confirmed TMDB id are written into one folder as they are synced. Nothing on disk is moved or renamed.

707 tests on the branch, 730 after merging main into it, all green.